### PR TITLE
Set the shell for the Makefile to be Bash so it can quote things correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # The sbv library is distributed with the BSD3 license. See the LICENSE file
 # in the distribution for details.
-
+SHELL := /usr/bin/env bash
 SRCS = $(shell find . -name '*.hs' -or -name '*.lhs' | grep -v SBVUnitTest/SBVUnitTest.hs)
 STAMPFILE=SBVUnitTest/SBVUnitTestBuildTime.hs
 


### PR DESCRIPTION
On Ubuntu, the 'make test' target doesn't work because vanilla sh doesn't understand the parenthesis used for the `time` commands. So this just sets the shell to bash specifically to fix that.
