### PR TITLE
assert negation of model + equivalence classes in allSat

### DIFF
--- a/SBVUnitTest/SBVTestCollection.hs
+++ b/SBVUnitTest/SBVTestCollection.hs
@@ -55,7 +55,8 @@ import qualified TestSuite.Puzzles.U2Bridge               as T09_10(testSuite)
 import qualified TestSuite.Uninterpreted.AUF              as T10_01(testSuite)
 import qualified TestSuite.Uninterpreted.Axioms           as T10_02(testSuite)
 import qualified TestSuite.Uninterpreted.Function         as T10_03(testSuite)
-import qualified TestSuite.Uninterpreted.Uninterpreted    as T10_04(testSuite)
+import qualified TestSuite.Uninterpreted.Sort             as T10_04(testSuite)
+import qualified TestSuite.Uninterpreted.Uninterpreted    as T10_05(testSuite)
 
 -- Bool says whether we need a real SMT solver to run this test
 -- Note that it's ok to say True even if an SMT solver is *not*
@@ -104,5 +105,6 @@ allTestCases = [
      , ("auf1",        True,  T10_01.testSuite)
      , ("unint-axms",  True,  T10_02.testSuite)
      , ("auf2",        True,  T10_03.testSuite)
-     , ("unint",       True,  T10_04.testSuite)
+     , ("unint-sort",  True,  T10_04.testSuite)
+     , ("unint",       True,  T10_05.testSuite)
      ]

--- a/SBVUnitTest/TestSuite/Uninterpreted/Sort.hs
+++ b/SBVUnitTest/TestSuite/Uninterpreted/Sort.hs
@@ -1,0 +1,44 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  TestSuite.Uninterpreted.Sort
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Test suite for uninterpreted sorts
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module TestSuite.Uninterpreted.Sort where
+
+import Data.SBV
+import SBVTest
+import Data.Generics
+
+-- Test suite
+testSuite :: SBVTestSuite
+testSuite = mkTestSuite $ \_ -> test [
+  "unint-sort" ~: assert . (==4) . length . (extractModels :: AllSatResult -> [L]) =<< allSat p0
+ ]
+
+data L = Nil | Cons Int L deriving (Eq, Ord, Data, Typeable)
+instance SymWord L
+instance HasKind L
+instance SatModel L where
+  parseCWs = undefined -- make GHC shut up about the missing method, we won't actually call it
+
+type SList = SBV L
+
+len :: SList -> SInteger
+len = uninterpret "len"
+
+p0 :: Symbolic SBool
+p0 = do
+    [l, l0, l1] <- symbolics ["l", "l0", "l1"]
+    constrain $ len l0 .== 0
+    constrain $ len l1 .== 1
+    x :: SInteger <- symbolic "x"
+    constrain $ x .== 0 ||| x.== 1
+    return $ l .== l0 ||| l .== l1


### PR DESCRIPTION
Sorry I didn't get around to submitting a pull request sooner! Your code does basically what mine did, with a small difference. I assert the negation of the model and the equivalence classes together, rather than splitting them into two separate assertions. I think this is the right thing to do because the results are more intuitive (to me at least :)). E.G.

``` haskell
p0 = do
    [l, l0, l1] <- symbolics ["l", "l0", "l1"]
    constrain $ len l0 .== 0
    constrain $ len l1 .== 1
    x :: SInteger <- symbolic "x"
    constrain $ x .== 0 ||| x.== 1
    return $ l .== l0 ||| l .== l1
```

In my opinion this should have 4 satisfying assignments, but your patch only finds 2.

Thanks!
