### PR TITLE
Make sBranch/symbolicMerge lazier; new function symbolicMergeWithKind

### DIFF
--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -833,8 +833,8 @@ mkSymSBVWithRandom rand mbQ k mbNm = do
                   (Nothing, CodeGen)          -> ALL -- code generation, pick universal
         case runMode st of
           Concrete _ | q == EX -> case mbNm of
-                                    Nothing -> error $ "Cannot quick-check in the presence of existential variables, type: " ++ showType (undefined :: SBV a)
-                                    Just nm -> error $ "Cannot quick-check in the presence of existential variable " ++ nm ++ " :: " ++ showType (undefined :: SBV a)
+                                    Nothing -> error $ "Cannot quick-check in the presence of existential variables, type: " ++ showType (undefined :: a)
+                                    Just nm -> error $ "Cannot quick-check in the presence of existential variable " ++ nm ++ " :: " ++ showType (undefined :: a)
           Concrete _           -> do v@(SBV _ (Left cw)) <- liftIO rand
                                      liftIO $ modifyIORef (rCInfo st) ((maybe "_" id mbNm, cw):)
                                      return v

--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -30,7 +30,7 @@ module Data.SBV.BitVectors.Model (
   , sWord32s, sWord64, sWord64s, sInt8, sInt8s, sInt16, sInt16s, sInt32, sInt32s, sInt64
   , sInt64s, sInteger, sIntegers, sReal, sReals, toSReal, sFloat, sFloats, sDouble, sDoubles, slet
   , fusedMA
-  , liftQRem, liftDMod, genLiteral
+  , liftQRem, liftDMod, genLiteral, symbolicMergeWithKind
   )
   where
 
@@ -1315,81 +1315,85 @@ sAssertCont msg cont t a
                      _                                        -> return trueSW
 
 -- SBV
+symbolicMergeWithKind :: SymWord a => Kind -> Bool -> SBool -> SBV a -> SBV a -> SBV a
+symbolicMergeWithKind k force t a b
+  | Just r <- unliteral t
+  = if r then a else b
+  | force, Just av <- unliteral a, Just bv <- unliteral b, rationalSBVCheck a b, av == bv
+  = a
+  | True
+  = SBV k $ Right $ cache c
+  where c st = do swt <- sbvToSW st t
+                  case () of
+                    () | swt == trueSW  -> sbvToSW st a       -- these two cases should never be needed as we expect symbolicMerge to be
+                    () | swt == falseSW -> sbvToSW st b       -- called with symbolic tests, but just in case..
+                    () -> do {- It is tempting to record the choice of the test expression here as we branch down to the 'then' and 'else' branches. That is,
+                                when we evaluate 'a', we can make use of the fact that the test expression is True, and similarly we can use the fact that it
+                                is False when b is evaluated. In certain cases this can cut down on symbolic simulation significantly, for instance if
+                                repetitive decisions are made in a recursive loop. Unfortunately, the implementation of this idea is quite tricky, due to
+                                our sharing based implementation. As the 'then' branch is evaluated, we will create many expressions that are likely going
+                                to be "reused" when the 'else' branch is executed. But, it would be *dead wrong* to share those values, as they were "cached"
+                                under the incorrect assumptions. To wit, consider the following:
+
+                                   foo x y = ite (y .== 0) k (k+1)
+                                     where k = ite (y .== 0) x (x+1)
+
+                                When we reduce the 'then' branch of the first ite, we'd record the assumption that y is 0. But while reducing the 'then' branch, we'd
+                                like to share 'k', which would evaluate (correctly) to 'x' under the given assumption. When we backtrack and evaluate the 'else'
+                                branch of the first ite, we'd see 'k' is needed again, and we'd look it up from our sharing map to find (incorrectly) that its value
+                                is 'x', which was stored there under the assumption that y was 0, which no longer holds. Clearly, this is unsound.
+
+                                A sound implementation would have to precisely track which assumptions were active at the time expressions get shared. That is,
+                                in the above example, we should record that the value of 'k' was cached under the assumption that 'y' is 0. While sound, this
+                                approach unfortunately leads to significant loss of valid sharing when the value itself had nothing to do with the assumption itself.
+                                To wit, consider:
+
+                                   foo x y = ite (y .== 0) k (k+1)
+                                     where k = x+5
+
+                                If we tracked the assumptions, we would recompute 'k' twice, since the branch assumptions would differ. Clearly, there is no need to
+                                re-compute 'k' in this case since its value is independent of y. Note that the whole SBV performance story is based on agressive sharing,
+                                and losing that would have other significant ramifications.
+
+                                The "proper" solution would be to track, with each shared computation, precisely which assumptions it actually *depends* on, rather
+                                than blindly recording all the assumptions present at that time. SBV's symbolic simulation engine clearly has all the info needed to do this
+                                properly, but the implementation is not straightforward at all. For each subexpression, we would need to chase down its dependencies
+                                transitively, which can require a lot of scanning of the generated program causing major slow-down; thus potentially defeating the
+                                whole purpose of sharing in the first place.
+
+                                Design choice: Keep it simple, and simply do not track the assumption at all. This will maximize sharing, at the cost of evaluating
+                                unreachable branches. I think the simplicity is more important at this point than efficiency.
+
+                                Also note that the user can avoid most such issues by properly combining if-then-else's with common conditions together. That is, the
+                                first program above should be written like this:
+
+                                  foo x y = ite (y .== 0) x (x+2)
+
+                                In general, the following transformations should be done whenever possible:
+
+                                  ite e1 (ite e1 e2 e3) e4  --> ite e1 e2 e4
+                                  ite e1 e2 (ite e1 e3 e4)  --> ite e1 e2 e4
+
+                                This is in accordance with the general rule-of-thumb stating conditionals should be avoided as much as possible. However, we might prefer
+                                the following:
+
+                                  ite e1 (f e2 e4) (f e3 e5) --> f (ite e1 e2 e3) (ite e1 e4 e5)
+
+                                especially if this expression happens to be inside 'f's body itself (i.e., when f is recursive), since it reduces the number of
+                                recursive calls. Clearly, programming with symbolic simulation in mind is another kind of beast alltogether.
+                             -}
+                             swa <- sbvToSW (st `extendPathCondition` (&&& t))      a -- evaluate 'then' branch
+                             swb <- sbvToSW (st `extendPathCondition` (&&& bnot t)) b -- evaluate 'else' branch
+                             case () of               -- merge:
+                               () | swa == swb                      -> return swa
+                               () | swa == trueSW && swb == falseSW -> return swt
+                               () | swa == falseSW && swb == trueSW -> newExpr st k (SBVApp Not [swt])
+                               ()                                   -> newExpr st k (SBVApp Ite [swt, swa, swb])
+
 instance SymWord a => Mergeable (SBV a) where
-    symbolicMerge force t a b
-      | Just r <- unliteral t
-      = if r then a else b
-      | force, Just av <- unliteral a, Just bv <- unliteral b, rationalSBVCheck a b, av == bv
-      = a
-      | True
-      = SBV k $ Right $ cache c
-      where k = kindOf a
-            c st = do swt <- sbvToSW st t
-                      case () of
-                        () | swt == trueSW  -> sbvToSW st a       -- these two cases should never be needed as we expect symbolicMerge to be
-                        () | swt == falseSW -> sbvToSW st b       -- called with symbolic tests, but just in case..
-                        () -> do {- It is tempting to record the choice of the test expression here as we branch down to the 'then' and 'else' branches. That is,
-                                    when we evaluate 'a', we can make use of the fact that the test expression is True, and similarly we can use the fact that it
-                                    is False when b is evaluated. In certain cases this can cut down on symbolic simulation significantly, for instance if
-                                    repetitive decisions are made in a recursive loop. Unfortunately, the implementation of this idea is quite tricky, due to
-                                    our sharing based implementation. As the 'then' branch is evaluated, we will create many expressions that are likely going
-                                    to be "reused" when the 'else' branch is executed. But, it would be *dead wrong* to share those values, as they were "cached"
-                                    under the incorrect assumptions. To wit, consider the following:
-
-                                       foo x y = ite (y .== 0) k (k+1)
-                                         where k = ite (y .== 0) x (x+1)
-
-                                    When we reduce the 'then' branch of the first ite, we'd record the assumption that y is 0. But while reducing the 'then' branch, we'd
-                                    like to share 'k', which would evaluate (correctly) to 'x' under the given assumption. When we backtrack and evaluate the 'else'
-                                    branch of the first ite, we'd see 'k' is needed again, and we'd look it up from our sharing map to find (incorrectly) that its value
-                                    is 'x', which was stored there under the assumption that y was 0, which no longer holds. Clearly, this is unsound.
-
-                                    A sound implementation would have to precisely track which assumptions were active at the time expressions get shared. That is,
-                                    in the above example, we should record that the value of 'k' was cached under the assumption that 'y' is 0. While sound, this
-                                    approach unfortunately leads to significant loss of valid sharing when the value itself had nothing to do with the assumption itself.
-                                    To wit, consider:
-
-                                       foo x y = ite (y .== 0) k (k+1)
-                                         where k = x+5
-
-                                    If we tracked the assumptions, we would recompute 'k' twice, since the branch assumptions would differ. Clearly, there is no need to
-                                    re-compute 'k' in this case since its value is independent of y. Note that the whole SBV performance story is based on agressive sharing,
-                                    and losing that would have other significant ramifications.
-
-                                    The "proper" solution would be to track, with each shared computation, precisely which assumptions it actually *depends* on, rather
-                                    than blindly recording all the assumptions present at that time. SBV's symbolic simulation engine clearly has all the info needed to do this
-                                    properly, but the implementation is not straightforward at all. For each subexpression, we would need to chase down its dependencies
-                                    transitively, which can require a lot of scanning of the generated program causing major slow-down; thus potentially defeating the
-                                    whole purpose of sharing in the first place.
-
-                                    Design choice: Keep it simple, and simply do not track the assumption at all. This will maximize sharing, at the cost of evaluating
-                                    unreachable branches. I think the simplicity is more important at this point than efficiency.
-
-                                    Also note that the user can avoid most such issues by properly combining if-then-else's with common conditions together. That is, the
-                                    first program above should be written like this:
-
-                                      foo x y = ite (y .== 0) x (x+2)
-
-                                    In general, the following transformations should be done whenever possible:
-
-                                      ite e1 (ite e1 e2 e3) e4  --> ite e1 e2 e4
-                                      ite e1 e2 (ite e1 e3 e4)  --> ite e1 e2 e4
-
-                                    This is in accordance with the general rule-of-thumb stating conditionals should be avoided as much as possible. However, we might prefer
-                                    the following:
-
-                                      ite e1 (f e2 e4) (f e3 e5) --> f (ite e1 e2 e3) (ite e1 e4 e5)
-
-                                   especially if this expression happens to be inside 'f's body itself (i.e., when f is recursive), since it reduces the number of
-                                   recursive calls. Clearly, programming with symbolic simulation in mind is another kind of beast alltogether.
-                                 -}
-                                 swa <- sbvToSW (st `extendPathCondition` (&&& t))      a -- evaluate 'then' branch
-                                 swb <- sbvToSW (st `extendPathCondition` (&&& bnot t)) b -- evaluate 'else' branch
-                                 case () of               -- merge:
-                                   () | swa == swb                      -> return swa
-                                   () | swa == trueSW && swb == falseSW -> return swt
-                                   () | swa == falseSW && swb == trueSW -> newExpr st k (SBVApp Not [swt])
-                                   ()                                   -> newExpr st k (SBVApp Ite [swt, swa, swb])
+    symbolicMerge force t x y =
+      symbolicMergeWithKind k force t x y
+      where k = if force then kindOf x else kindOf (undefined :: a)
     -- Custom version of select that translates to SMT-Lib tables at the base type of words
     select xs err ind
       | SBV _ (Left c) <- ind = case cwVal c of
@@ -1862,9 +1866,9 @@ instance Testable (Symbolic SBool) where
 -- However, there might be times where being explicit on the sharing can help, especially in experimental code. The 'slet' combinator
 -- ensures that its first argument is computed once and passed on to its continuation, explicitly indicating the intent of sharing. Most
 -- use cases of the SBV library should simply use Haskell's @let@ construct for this purpose.
-slet :: (HasKind a, HasKind b) => SBV a -> (SBV a -> SBV b) -> SBV b
+slet :: forall a b. (HasKind a, HasKind b) => SBV a -> (SBV a -> SBV b) -> SBV b
 slet x f = SBV k $ Right $ cache r
-    where k    = kindOf (undefined `asTypeOf` f x)
+    where k    = kindOf (undefined :: b)
           r st = do xsw <- sbvToSW st x
                     let xsbv = SBV (kindOf x) (Right (cache (const (return xsw))))
                         res  = f xsbv

--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -16,7 +16,7 @@ module Data.SBV.Internals (
   Result, SBVRunMode(..), runSymbolic, runSymbolic'
   -- * Other internal structures useful for low-level programming
   , SBV(..), slet, CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW, genVar, genVar_
-  , liftQRem, liftDMod, genLiteral
+  , liftQRem, liftDMod, genLiteral, symbolicMergeWithKind
   , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom
   -- * Compilation to C
   , compileToC', compileToCLib', CgPgmBundle(..), CgPgmKind(..)
@@ -24,6 +24,6 @@ module Data.SBV.Internals (
 
 import Data.SBV.BitVectors.Data   (Result, SBVRunMode(..), runSymbolic, runSymbolic', SBV(..), CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW)
 import Data.SBV.BitVectors.Data   (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom)
-import Data.SBV.BitVectors.Model  (genVar, genVar_, slet, liftQRem, liftDMod, genLiteral)
+import Data.SBV.BitVectors.Model  (genVar, genVar_, slet, liftQRem, liftDMod, genLiteral, symbolicMergeWithKind)
 import Data.SBV.Compilers.C       (compileToC', compileToCLib')
 import Data.SBV.Compilers.CodeGen (CgPgmBundle(..), CgPgmKind(..))


### PR DESCRIPTION
This should fix the broken sBranch test from issue #108.

In this changeset, `kindOf` is still the strict version. (I have another patch that replaces this with a new function; it just adds a lot of noise to the diff.) I found that in nearly all cases where `kindOf` is used at type `SBV a -> Kind`, the function is already strict in the argument. In the other few places where laziness is necessary, I use `kindOf (undefined :: a)`.

I suspect the lazy `kindOf` might have an advantage in terms of compiler optimizations where the type instantiation is known, so you might want to switch to the lazy version in some places. If this is the case, we can create a new issue and discuss it there.