### PR TITLE
Data.SBV.Internals exports more functions useful for class instances

### DIFF
--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -30,7 +30,8 @@ module Data.SBV.BitVectors.Model (
   , sWord32s, sWord64, sWord64s, sInt8, sInt8s, sInt16, sInt16s, sInt32, sInt32s, sInt64
   , sInt64s, sInteger, sIntegers, sReal, sReals, toSReal, sFloat, sFloats, sDouble, sDoubles, slet
   , fusedMA
-  , liftQRem, liftDMod, genLiteral, symbolicMergeWithKind
+  , liftQRem, liftDMod, symbolicMergeWithKind
+  , genLiteral, genFromCW, genMkSymVar
   )
   where
 

--- a/Data/SBV/BitVectors/Splittable.hs
+++ b/Data/SBV/BitVectors/Splittable.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE BangPatterns           #-}
 
-module Data.SBV.BitVectors.Splittable (Splittable(..), FromBits(..)) where
+module Data.SBV.BitVectors.Splittable (Splittable(..), FromBits(..), checkAndConvert) where
 
 import Data.Bits (Bits(..))
 import Data.Word (Word8, Word16, Word32, Word64)

--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -16,14 +16,18 @@ module Data.SBV.Internals (
   Result, SBVRunMode(..), runSymbolic, runSymbolic'
   -- * Other internal structures useful for low-level programming
   , SBV(..), slet, CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW, genVar, genVar_
-  , liftQRem, liftDMod, genLiteral, symbolicMergeWithKind
+  , liftQRem, liftDMod, symbolicMergeWithKind
   , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom
+  -- * Operations useful for instantiating SBV type classes
+  , genLiteral, genFromCW, genMkSymVar, checkAndConvert, genParse
   -- * Compilation to C
   , compileToC', compileToCLib', CgPgmBundle(..), CgPgmKind(..)
   ) where
 
 import Data.SBV.BitVectors.Data   (Result, SBVRunMode(..), runSymbolic, runSymbolic', SBV(..), CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW)
 import Data.SBV.BitVectors.Data   (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom)
-import Data.SBV.BitVectors.Model  (genVar, genVar_, slet, liftQRem, liftDMod, genLiteral, symbolicMergeWithKind)
+import Data.SBV.BitVectors.Model  (genVar, genVar_, slet, liftQRem, liftDMod, symbolicMergeWithKind, genLiteral, genFromCW, genMkSymVar)
+import Data.SBV.BitVectors.Splittable (checkAndConvert)
 import Data.SBV.Compilers.C       (compileToC', compileToCLib')
 import Data.SBV.Compilers.CodeGen (CgPgmBundle(..), CgPgmKind(..))
+import Data.SBV.SMT.SMT           (genParse)


### PR DESCRIPTION
This is the part of the Word4 example that only includes the changes to the main library. It is enough on its own to address my concerns in issue #104.