### PR TITLE
Add ABC prover

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -228,7 +228,7 @@ module Data.SBV (
   , getModelDictionaries, getModelValues, getModelUninterpretedValues
 
   -- * SMT Interface: Configurations and solvers
-  , SMTConfig(..), SMTLibLogic(..), Logic(..), OptimizeOpts(..), Solver(..), SMTSolver(..), boolector, cvc4, yices, z3, mathSAT, defaultSolverConfig, sbvCurrentSolver, defaultSMTCfg, sbvCheckSolverInstallation, sbvAvailableSolvers
+  , SMTConfig(..), SMTLibLogic(..), Logic(..), OptimizeOpts(..), Solver(..), SMTSolver(..), boolector, cvc4, yices, z3, mathSAT, abc, defaultSolverConfig, sbvCurrentSolver, defaultSMTCfg, sbvCheckSolverInstallation, sbvAvailableSolvers
 
   -- * Symbolic computations
   , Symbolic, output, SymWord(..)
@@ -346,6 +346,7 @@ defaultSolverConfig Yices     = yices
 defaultSolverConfig Boolector = boolector
 defaultSolverConfig CVC4      = cvc4
 defaultSolverConfig MathSAT   = mathSAT
+defaultSolverConfig ABC       = abc
 
 -- | Return the known available solver configs, installed on your machine.
 sbvAvailableSolvers :: IO [SMTConfig]

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -1480,6 +1480,7 @@ data Solver = Z3
             | Boolector
             | CVC4
             | MathSAT
+            | ABC
             deriving (Show, Enum, Bounded)
 
 -- | An SMT solver

--- a/Data/SBV/Bridge/ABC.hs
+++ b/Data/SBV/Bridge/ABC.hs
@@ -1,0 +1,113 @@
+---------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.Bridge.ABC
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Interface to the ABC verification and synthesis tool. Import this
+-- module if you want to use ABC as your backend solver. Also see:
+--
+--       - "Data.SBV.Bridge.Yices"
+--
+--       - "Data.SBV.Bridge.Z3"
+--
+--       - "Data.SBV.Bridge.Boolector"
+--
+--       - "Data.SBV.Bridge.MathSAT"
+--
+--       - "Data.SBV.Bridge.CVC4"
+---------------------------------------------------------------------------------
+
+module Data.SBV.Bridge.ABC (
+  -- * ABC specific interface
+  sbvCurrentSolver
+  -- ** Proving, checking satisfiability, and safety
+  , prove, sat, safe, allSat, isVacuous, isTheorem, isSatisfiable
+  -- ** Optimization routines
+  , optimize, minimize, maximize
+  , module Data.SBV
+  ) where
+
+import Data.SBV hiding (prove, sat, safe, allSat, isVacuous, isTheorem, isSatisfiable, optimize, minimize, maximize, sbvCurrentSolver)
+
+-- | Current solver instance, pointing to abc.
+sbvCurrentSolver :: SMTConfig
+sbvCurrentSolver = abc
+
+-- | Prove theorems, using ABC
+prove :: Provable a
+      => a              -- ^ Property to check
+      -> IO ThmResult   -- ^ Response from the SMT solver, containing the counter-example if found
+prove = proveWith sbvCurrentSolver
+
+-- | Find satisfying solutions, using ABC
+sat :: Provable a
+    => a                -- ^ Property to check
+    -> IO SatResult     -- ^ Response of the SMT Solver, containing the model if found
+sat = satWith sbvCurrentSolver
+
+-- | Check safety, i.e., prove that all 'sAssert' conditions are statically true in all paths
+safe :: SExecutable a
+     => a               -- ^ Program to check the safety of
+     -> IO SafeResult   -- ^ Response of the SMT solver, containing the unsafe model if found
+safe = safeWith sbvCurrentSolver
+
+-- | Find all satisfying solutions, using ABC
+allSat :: Provable a
+       => a                -- ^ Property to check
+       -> IO AllSatResult  -- ^ List of all satisfying models
+allSat = allSatWith sbvCurrentSolver
+
+-- | Check vacuity of the explicit constraints introduced by calls to the 'constrain' function, using ABC
+isVacuous :: Provable a
+          => a             -- ^ Property to check
+          -> IO Bool       -- ^ True if the constraints are unsatisifiable
+isVacuous = isVacuousWith sbvCurrentSolver
+
+-- | Check if the statement is a theorem, with an optional time-out in seconds, using ABC
+isTheorem :: Provable a
+          => Maybe Int          -- ^ Optional time-out, specify in seconds
+          -> a                  -- ^ Property to check
+          -> IO (Maybe Bool)    -- ^ Returns Nothing if time-out expires
+isTheorem = isTheoremWith sbvCurrentSolver
+
+-- | Check if the statement is satisfiable, with an optional time-out in seconds, using ABC
+isSatisfiable :: Provable a
+              => Maybe Int       -- ^ Optional time-out, specify in seconds
+              -> a               -- ^ Property to check
+              -> IO (Maybe Bool) -- ^ Returns Nothing if time-out expiers
+isSatisfiable = isSatisfiableWith sbvCurrentSolver
+
+-- | Optimize cost functions, using ABC
+optimize :: (SatModel a, SymWord a, Show a, SymWord c, Show c)
+         => OptimizeOpts                -- ^ Parameters to optimization (Iterative, Quantified, etc.)
+         -> (SBV c -> SBV c -> SBool)   -- ^ Betterness check: This is the comparison predicate for optimization
+         -> ([SBV a] -> SBV c)          -- ^ Cost function
+         -> Int                         -- ^ Number of inputs
+         -> ([SBV a] -> SBool)          -- ^ Validity function
+         -> IO (Maybe [a])              -- ^ Returns Nothing if there is no valid solution, otherwise an optimal solution
+optimize = optimizeWith sbvCurrentSolver
+
+-- | Minimize cost functions, using ABC
+minimize :: (SatModel a, SymWord a, Show a, SymWord c, Show c)
+         => OptimizeOpts                -- ^ Parameters to optimization (Iterative, Quantified, etc.)
+         -> ([SBV a] -> SBV c)          -- ^ Cost function to minimize
+         -> Int                         -- ^ Number of inputs
+         -> ([SBV a] -> SBool)          -- ^ Validity function
+         -> IO (Maybe [a])              -- ^ Returns Nothing if there is no valid solution, otherwise an optimal solution
+minimize = minimizeWith sbvCurrentSolver
+
+-- | Maximize cost functions, using ABC
+maximize :: (SatModel a, SymWord a, Show a, SymWord c, Show c)
+         => OptimizeOpts                -- ^ Parameters to optimization (Iterative, Quantified, etc.)
+         -> ([SBV a] -> SBV c)          -- ^ Cost function to maximize
+         -> Int                         -- ^ Number of inputs
+         -> ([SBV a] -> SBool)          -- ^ Validity function
+         -> IO (Maybe [a])              -- ^ Returns Nothing if there is no valid solution, otherwise an optimal solution
+maximize = maximizeWith sbvCurrentSolver
+
+{- $moduleExportIntro
+The remainder of the SBV library that is common to all back-end SMT solvers, directly coming from the "Data.SBV" module.
+-}

--- a/Data/SBV/Provers/ABC.hs
+++ b/Data/SBV/Provers/ABC.hs
@@ -17,7 +17,7 @@ import qualified Control.Exception as C
 
 import Data.Char          (isSpace)
 import Data.Function      (on)
-import Data.List          (intercalate, sortBy, isPrefixOf)
+import Data.List          (intercalate, sortBy)
 import System.Environment (getEnv)
     
 import Data.SBV.BitVectors.Data

--- a/Data/SBV/Provers/ABC.hs
+++ b/Data/SBV/Provers/ABC.hs
@@ -50,9 +50,9 @@ abc = SMTSolver {
                                 -- TODO: what are the right answers for these?
                                 , supportsMacros             = True
                                 , supportsProduceModels      = True
-                                , supportsQuantifiers        = True
-                                , supportsUninterpretedSorts = True
-                                , supportsUnboundedInts      = True
+                                , supportsQuantifiers        = False
+                                , supportsUninterpretedSorts = False
+                                , supportsUnboundedInts      = False
                                 , supportsReals              = False
                                 , supportsFloats             = False
                                 , supportsDoubles            = False
@@ -61,7 +61,7 @@ abc = SMTSolver {
  where zero :: Kind -> String
        zero KBool                = "false"
        zero (KBounded _     sz)  = "#x" ++ replicate (sz `div` 4) '0'
-       zero KUnbounded           = "0"
+       zero KUnbounded           = error "SBV.ABC.zero: Unexpected unbounded int value"
        zero KReal                = error "SBV.ABC.zero: Unexpected real value"
        zero KFloat               = error "SBV.ABC.zero: Unexpected float value"
        zero KDouble              = error "SBV.ABC.zero: Unexpected double value"
@@ -73,7 +73,8 @@ abc = SMTSolver {
               extract (Right (s, [])) = "(get-value (" ++ show s ++ "))"
               extract (Right (s, ss)) = "(get-value (" ++ show s ++ concat [' ' : zero (kindOf a) | a <- ss] ++ "))"
 
--- TODO: this is still the cvc4 one...
+-- XXX: this is copied from the CVC4 module, and is probably much more
+-- than is needed for ABC
 extractMap :: Bool -> [(Quantifier, NamedSymVar)] -> [(String, UnintKind)] -> [String] -> SMTModel
 extractMap isSat qinps _modelMap solverLines =
    SMTModel { modelAssocs    = map snd $ sortByNodeId $ concatMap (interpretSolverModelLine inps . unstring) solverLines

--- a/Data/SBV/Provers/ABC.hs
+++ b/Data/SBV/Provers/ABC.hs
@@ -1,0 +1,99 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.Provers.ABC
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- The connection to the ABC verification and synthesis tool
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.SBV.Provers.ABC(abc) where
+
+import qualified Control.Exception as C
+
+import Data.Char          (isSpace)
+import Data.Function      (on)
+import Data.List          (intercalate, sortBy, isPrefixOf)
+import System.Environment (getEnv)
+    
+import Data.SBV.BitVectors.Data
+import Data.SBV.SMT.SMT
+import Data.SBV.SMT.SMTLib
+
+-- | The description of abc. The default executable is @\"abc\"@,
+-- which must be in your path. You can use the @SBV_ABC@ environment
+-- variable to point to the executable on your system.  There are no
+-- default options. You can use the @SBV_ABC_OPTIONS@ environment
+-- variable to override the options.
+abc :: SMTSolver
+abc = SMTSolver {
+           name           = ABC
+         , executable     = "abc"
+         , options        = ["-S", "%blast; &put; dsat -s"]
+         , engine         = \cfg isSat qinps modelMap skolemMap pgm -> do
+                                    execName <-               getEnv "SBV_ABC"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (words `fmap` getEnv "SBV_ABC_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    let cfg' = cfg { solver = (solver cfg) {executable = execName, options = execOpts} }
+                                        tweaks = case solverTweaks cfg' of
+                                                   [] -> ""
+                                                   ts -> unlines $ "; --- user given solver tweaks ---" : ts ++ ["; --- end of user given tweaks ---"]
+                                        script = SMTScript {scriptBody = tweaks ++ pgm, scriptModel = Just (cont skolemMap)}
+                                    standardSolver cfg' script id (ProofError cfg') (interpretAbcOutput cfg' (extractMap isSat qinps modelMap))
+         , xformExitCode  = id
+         , capabilities   = SolverCapabilities {
+                                  capSolverName              = "ABC"
+                                , mbDefaultLogic             = Nothing
+                                , supportsMacros             = True
+                                , supportsProduceModels      = True
+                                , supportsQuantifiers        = True
+                                , supportsUninterpretedSorts = True
+                                , supportsUnboundedInts      = True
+                                , supportsReals              = False
+                                , supportsFloats             = False
+                                , supportsDoubles            = False
+                                }
+         }
+ where zero :: Kind -> String
+       zero KBool                = "false"
+       zero (KBounded _     sz)  = "#x" ++ replicate (sz `div` 4) '0'
+       zero KUnbounded           = "0"
+       zero KReal                = error "SBV.ABC.zero: Unexpected real value"
+       zero KFloat               = error "SBV.ABC.zero: Unexpected float value"
+       zero KDouble              = error "SBV.ABC.zero: Unexpected double value"
+       -- For uninterpreted sorts, we use the first element of the enumerations if available; otherwise bail out..
+       zero (KUserSort _ (Right (f:_), _)) = f
+       zero (KUserSort s _)                = error $ "SBV.ABC.zero: Unexpected uninterpreted sort: " ++ s
+       cont skolemMap = intercalate "\n" $ map extract skolemMap
+        where extract (Left s)        = "(echo \"((" ++ show s ++ " " ++ zero (kindOf s) ++ "))\")"
+              extract (Right (s, [])) = "(get-value (" ++ show s ++ "))"
+              extract (Right (s, ss)) = "(get-value (" ++ show s ++ concat [' ' : zero (kindOf a) | a <- ss] ++ "))"
+
+extractMap :: Bool -> [(Quantifier, NamedSymVar)] -> [(String, UnintKind)] -> [String] -> SMTModel
+extractMap isSat qinps _modelMap solverLines =
+   SMTModel { modelAssocs    = map snd $ sortByNodeId $ concatMap (interpretSolverModelLine inps . unstring) solverLines
+            , modelUninterps = []
+            , modelArrays    = []
+            }
+  where sortByNodeId :: [(Int, a)] -> [(Int, a)]
+        sortByNodeId = sortBy (compare `on` fst)
+        inps -- for "sat", display the prefix existentials. For completeness, we will drop
+             -- only the trailing foralls. Exception: Don't drop anything if it's all a sequence of foralls
+             | isSat = map snd $ if all (== ALL) (map fst qinps)
+                                 then qinps
+                                 else reverse $ dropWhile ((== ALL) . fst) $ reverse qinps
+             -- for "proof", just display the prefix universals
+             | True  = map snd $ takeWhile ((== ALL) . fst) qinps
+        unstring s' = case (s, head s, last s) of
+                        (_:tl@(_:_), '"', '"') -> init tl
+                        _                      -> s'
+          where s = reverse . dropWhile isSpace . reverse . dropWhile isSpace $ s'
+
+-- | Interpret ABC output
+interpretAbcOutput :: SMTConfig -> ([String] -> SMTModel) -> [String] -> SMTResult
+interpretAbcOutput cfg _          (l:_)    | "UNSATISFIABLE" `isPrefixOf` l = Unsatisfiable cfg
+interpretAbcOutput cfg extractMap (l:rest) | "SATISFIABLE"   `isPrefixOf` l = Satisfiable   cfg  $ extractMap rest
+interpretAbcOutput cfg _          ls                                        = ProofError    cfg  ls

--- a/Data/SBV/Provers/Prover.hs
+++ b/Data/SBV/Provers/Prover.hs
@@ -26,7 +26,7 @@ module Data.SBV.Provers.Prover (
        , isVacuous, isVacuousWith
        , SatModel(..), Modelable(..), displayModels, extractModels
        , getModelDictionaries, getModelValues, getModelUninterpretedValues
-       , boolector, cvc4, yices, z3, mathSAT, defaultSMTCfg
+       , boolector, cvc4, yices, z3, mathSAT, abc, defaultSMTCfg
        , compileToSMTLib, generateSMTBenchmarks
        , isSBranchFeasibleInState
        , isConditionSatisfiable
@@ -52,6 +52,7 @@ import qualified Data.SBV.Provers.CVC4       as CVC4
 import qualified Data.SBV.Provers.Yices      as Yices
 import qualified Data.SBV.Provers.Z3         as Z3
 import qualified Data.SBV.Provers.MathSAT    as MathSAT
+import qualified Data.SBV.Provers.ABC        as ABC
 import Data.SBV.Utils.TDiff
 
 mkConfig :: SMTSolver -> Bool -> [String] -> SMTConfig
@@ -89,6 +90,10 @@ z3 = mkConfig Z3.z3 True ["(set-option :smt.mbqi true) ; use model based quantif
 -- | Default configuration for the MathSAT SMT solver
 mathSAT :: SMTConfig
 mathSAT = mkConfig MathSAT.mathSAT True []
+
+-- | Default configuration for the ABC synthesis and verification tool.
+abc :: SMTConfig
+abc = mkConfig ABC.abc True []
 
 -- | The default solver used by SBV. This is currently set to z3.
 defaultSMTCfg :: SMTConfig

--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -27,7 +27,7 @@ import Data.Word          (Word8, Word16, Word32, Word64)
 import System.Directory   (findExecutable)
 import System.Process     (runInteractiveProcess, waitForProcess, terminateProcess)
 import System.Exit        (ExitCode(..))
-import System.IO          (hClose, hFlush, hPutStr, hGetContents, hGetLine, hSetBuffering, BufferMode(..))
+import System.IO          (hClose, hFlush, hPutStr, hGetContents, hGetLine)
 
 import qualified Data.Map as M
 import Data.Typeable
@@ -447,13 +447,8 @@ runSolver cfg execPath opts script
  = do (send, ask, cleanUp, pid) <- do
                 (inh, outh, errh, pid) <- runInteractiveProcess execPath opts Nothing Nothing
                 hSetBuffering inh NoBuffering
-                let send l    = do
-                      when (verbose cfg) $ putStrLn ("> " ++ l)
-                      hPutStr inh (l ++ "\n") >> hFlush inh
-                    recv      = do
-                      l <- hGetLine outh
-                      when (verbose cfg) $ putStrLn ("< " ++ l)
-                      return l
+                let send l    = hPutStr inh (l ++ "\n") >> hFlush inh
+                    recv      = hGetLine outh
                     ask l     = send l >> recv
                     cleanUp response
                         = do hClose inh

--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -446,7 +446,6 @@ runSolver :: SMTConfig -> FilePath -> [String] -> SMTScript -> IO (ExitCode, Str
 runSolver cfg execPath opts script
  = do (send, ask, cleanUp, pid) <- do
                 (inh, outh, errh, pid) <- runInteractiveProcess execPath opts Nothing Nothing
-                hSetBuffering inh NoBuffering
                 let send l    = hPutStr inh (l ++ "\n") >> hFlush inh
                     recv      = hGetLine outh
                     ask l     = send l >> recv

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -55,6 +55,7 @@ Library
                   , Data.SBV.Bridge.MathSAT
                   , Data.SBV.Bridge.Yices
                   , Data.SBV.Bridge.Z3
+                  , Data.SBV.Bridge.ABC
                   , Data.SBV.Internals
                   , Data.SBV.Examples.BitPrecise.BitTricks
                   , Data.SBV.Examples.BitPrecise.Legato

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -111,6 +111,7 @@ Library
                   , Data.SBV.Provers.Yices
                   , Data.SBV.Provers.Z3
                   , Data.SBV.Provers.MathSAT
+                  , Data.SBV.Provers.ABC
                   , Data.SBV.Tools.ExpectedValue
                   , Data.SBV.Tools.GenTest
                   , Data.SBV.Tools.Optimize


### PR DESCRIPTION
__This isn't working yet, don't merge it!__ I just wanted to get the pull request open so we can mark comments on the code.

Alan has implemented much of the SMTLIB style interface in ABC. If you run `abc -S '%some; &abc; commands'`, it'll read SMTLIB from stdin until it sees `(check-sat)`, at which point it'll run whatever commands you passed as the `-S` argument. After that, it supports `get-value` calls until you send EOF.

The problem I'm running into is in the communication between SBV and ABC at the `(check-sat)` call. I've added some debugging output to try diagnosing it, but for whatever reason it's hanging after sending `(check-sat)` to ABC, presumably waiting to see whether it's `unsat` or `sat` so it can ask for a model if `sat`.

If I try typing in a small proof script line-by-line to ABC interactively, it returns the result right away, but I'm not seeing the same thing when SBV is driving. Any ideas?

```
** Starting symbolic simulation..
** Elapsed problem construction time: 0.000s
** Generated symbolic trace:
False
** Translating to SMT-Lib..
** Elapsed translation time: 0.000s
** Checking Theoremhood..
** Generated SMTLib program:
; Automatically generated by SBV. Do not edit.
(set-option :produce-models true)
(set-logic QF_BV)
; --- uninterpreted sorts ---
; --- literal constants ---
(define-fun s_2 () Bool false)
(define-fun s_1 () Bool true)
; --- skolem constants ---
; --- constant tables ---
; --- skolemized tables ---
; --- arrays ---
; --- uninterpreted constants ---
; --- user given axioms ---
; --- formula ---
(assert ; no quantifiers
   (not s_2))
** Calling: "abc -S %blast; &put; dsat -s"
> ; Automatically generated by SBV. Do not edit.
> (set-option :produce-models true)
> (set-logic QF_BV)
> ; --- uninterpreted sorts ---
> ; --- literal constants ---
> (define-fun s_2 () Bool false)
> (define-fun s_1 () Bool true)
> ; --- skolem constants ---
> ; --- constant tables ---
> ; --- skolemized tables ---
> ; --- arrays ---
> ; --- uninterpreted constants ---
> ; --- user given axioms ---
> ; --- formula ---
> (assert ; no quantifiers
>    (not s_2))
> (check-sat)
^CCtrl-C
** Elapsed ABC time: 6.673s
** ABC output:
Failed to start the external solver: thread killed
Make sure you can start "/Users/acfoltzer/bin/abc"
from the command line without issues.
```

```
% abc -S '%blast; &put; dsat -s'
(set-option :produce-models true)
(set-logic QF_BV)
(define-fun s_2 () Bool false)
(define-fun s_1 () Bool true)
(assert 
  (not s_1))
(check-sat)
unsat
```