### PR TITLE
Make the implementations of `rnf` explicit.

### DIFF
--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -1318,8 +1318,8 @@ data SMTLibVersion = SMTLib1
 data SMTLibPgm = SMTLibPgm SMTLibVersion  ( [(String, SW)]          -- alias table
                                           , [String]                -- pre: declarations.
                                           , [String])               -- post: formula
-instance NFData SMTLibVersion
-instance NFData SMTLibPgm
+instance NFData SMTLibVersion where rnf a = seq a ()
+instance NFData SMTLibPgm     where rnf a = seq a ()
 
 instance Show SMTLibPgm where
   show (SMTLibPgm _ (_, pre, post)) = intercalate "\n" $ pre ++ post
@@ -1334,18 +1334,19 @@ instance NFData Result where
                        `seq` rnf consts `seq` rnf tbls `seq` rnf arrs
                        `seq` rnf uis    `seq` rnf axs  `seq` rnf pgm
                        `seq` rnf cstr   `seq` rnf outs
-instance NFData Kind
-instance NFData ArrayContext
-instance NFData SW
-instance NFData SBVExpr
-instance NFData Quantifier
-instance NFData SBVType
-instance NFData UnintKind
+instance NFData Kind          where rnf a = seq a ()
+instance NFData ArrayContext  where rnf a = seq a ()
+instance NFData SW            where rnf a = seq a ()
+instance NFData SBVExpr       where rnf a = seq a ()
+instance NFData Quantifier    where rnf a = seq a ()
+instance NFData SBVType       where rnf a = seq a ()
+instance NFData UnintKind     where rnf a = seq a ()
 instance NFData a => NFData (Cached a) where
   rnf (Cached f) = f `seq` ()
 instance NFData a => NFData (SBV a) where
   rnf (SBV x y) = rnf x `seq` rnf y `seq` ()
-instance NFData SBVPgm
+instance NFData SBVPgm        where rnf a = seq a ()
+
 
 instance NFData SMTResult where
   rnf (Unsatisfiable _)   = ()


### PR DESCRIPTION
This makes `sbv` work with both GHC 7.8 and GHC 7.10.

The issue is that in GHC 7.10 the default implementation of the `rnf` method changes to use the `Generic`
class, but `sbv` does not provide `Generic` instances for its types.

The fix is to provide an explicit definition for the method, which behaves like the old default, i.e., fall back
to using `seq`.

It may be good to revisit these instances and check that using `seq` is indeed the desired behavior but, for now, this should provide no change in behavior.

