### PR TITLE
Export function `forceSWArg` from SBV.Internals

### DIFF
--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -18,7 +18,7 @@ module Data.SBV.Internals (
   , SBV(..), slet, CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW, genVar, genVar_
   , liftQRem, liftDMod, symbolicMergeWithKind
   , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom
-  , SBVType(..), newUninterpreted
+  , SBVType(..), newUninterpreted, forceSWArg
   -- * Operations useful for instantiating SBV type classes
   , genLiteral, genFromCW, genMkSymVar, checkAndConvert, genParse
   -- * Compilation to C
@@ -26,7 +26,7 @@ module Data.SBV.Internals (
   ) where
 
 import Data.SBV.BitVectors.Data       (Result, SBVRunMode(..), runSymbolic, runSymbolic', SBV(..), CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW)
-import Data.SBV.BitVectors.Data       (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom, SBVType(..), newUninterpreted)
+import Data.SBV.BitVectors.Data       (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom, SBVType(..), newUninterpreted, forceSWArg)
 import Data.SBV.BitVectors.Model      (genVar, genVar_, slet, liftQRem, liftDMod, symbolicMergeWithKind, genLiteral, genFromCW, genMkSymVar)
 import Data.SBV.BitVectors.Splittable (checkAndConvert)
 import Data.SBV.Compilers.C           (compileToC', compileToCLib')


### PR DESCRIPTION
This function is useful for defining Uninterpreted class instances
or producing uninterpreted SBV values of arbitrary kinds.

This is the last export we need in order to get uninterpreted functions working properly in the SAW tools.