### PR TITLE
handle quotes in SBV_$SOLVER_OPTIONS

### DIFF
--- a/Data/SBV/Provers/ABC.hs
+++ b/Data/SBV/Provers/ABC.hs
@@ -23,6 +23,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum (mkSkolemZero)
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- | The description of abc. The default executable is @\"abc\"@,
 -- which must be in your path. You can use the @SBV_ABC@ environment
@@ -35,8 +36,8 @@ abc = SMTSolver {
          , executable     = "abc"
          , options        = ["-S", "%blast; &put; dsat -s"]
          , engine         = \cfg isSat qinps modelMap skolemMap pgm -> do
-                                    execName <-               getEnv "SBV_ABC"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap` getEnv "SBV_ABC_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                   getEnv "SBV_ABC"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap` getEnv "SBV_ABC_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg' = cfg { solver = (solver cfg) {executable = execName, options = execOpts} }
                                         tweaks = case solverTweaks cfg' of
                                                    [] -> ""

--- a/Data/SBV/Provers/Boolector.hs
+++ b/Data/SBV/Provers/Boolector.hs
@@ -24,6 +24,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum (mkSkolemZero)
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- | The description of the Boolector SMT solver
 -- The default executable is @\"boolector\"@, which must be in your path. You can use the @SBV_BOOLECTOR@ environment variable to point to the executable on your system.
@@ -34,8 +35,8 @@ boolector = SMTSolver {
          , executable     = "boolector"
          , options        = ["--smt2", "--smt2-model"]
          , engine         = \cfg _isSat qinps modelMap skolemMap pgm -> do
-                                    execName <-               getEnv "SBV_BOOLECTOR"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap` getEnv "SBV_BOOLECTOR_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                   getEnv "SBV_BOOLECTOR"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap` getEnv "SBV_BOOLECTOR_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg' = cfg {solver = (solver cfg) {executable = execName, options = addTimeOut (timeOut cfg) execOpts}}
                                         tweaks = case solverTweaks cfg' of
                                                    [] -> ""

--- a/Data/SBV/Provers/CVC4.hs
+++ b/Data/SBV/Provers/CVC4.hs
@@ -25,6 +25,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum (mkSkolemZero)
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- | The description of the CVC4 SMT solver
 -- The default executable is @\"cvc4\"@, which must be in your path. You can use the @SBV_CVC4@ environment variable to point to the executable on your system.
@@ -35,8 +36,8 @@ cvc4 = SMTSolver {
          , executable     = "cvc4"
          , options        = ["--lang", "smt"]
          , engine         = \cfg isSat qinps modelMap skolemMap pgm -> do
-                                    execName <-               getEnv "SBV_CVC4"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap` getEnv "SBV_CVC4_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                   getEnv "SBV_CVC4"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap` getEnv "SBV_CVC4_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg' = cfg { solver = (solver cfg) {executable = execName, options = addTimeOut (timeOut cfg) execOpts} }
                                         tweaks = case solverTweaks cfg' of
                                                    [] -> ""

--- a/Data/SBV/Provers/MathSAT.hs
+++ b/Data/SBV/Provers/MathSAT.hs
@@ -23,6 +23,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum (mkSkolemZero)
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- | The description of the MathSAT SMT solver
 -- The default executable is @\"mathsat\"@, which must be in your path. You can use the @SBV_MATHSAT@ environment variable to point to the executable on your system.
@@ -33,8 +34,8 @@ mathSAT = SMTSolver {
          , executable     = "mathsat"
          , options        = ["-input=smt2"]
          , engine         = \cfg _isSat qinps modelMap skolemMap pgm -> do
-                                    execName <-               getEnv "SBV_MATHSAT"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap` getEnv "SBV_MATHSAT_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                   getEnv "SBV_MATHSAT"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap` getEnv "SBV_MATHSAT_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg' = cfg { solver = (solver cfg) {executable = execName, options = addTimeOut (timeOut cfg) execOpts}
                                                    }
                                         tweaks = case solverTweaks cfg' of

--- a/Data/SBV/Provers/Yices.hs
+++ b/Data/SBV/Provers/Yices.hs
@@ -25,6 +25,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.Provers.SExpr
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- | The description of the Yices SMT solver
 -- The default executable is @\"yices-smt\"@, which must be in your path. You can use the @SBV_YICES@ environment variable to point to the executable on your system.
@@ -36,8 +37,8 @@ yices = SMTSolver {
          -- , options        = ["-tc", "-smt", "-e"]   -- For Yices1
          , options        = ["-m", "-f"]  -- For Yices2
          , engine         = \cfg _isSat qinps modelMap _skolemMap pgm -> do
-                                    execName <-                getEnv "SBV_YICES"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap`  getEnv "SBV_YICES_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                    getEnv "SBV_YICES"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap`  getEnv "SBV_YICES_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg'   = cfg {solver = (solver cfg) {executable = execName, options = addTimeOut (timeOut cfg) execOpts}}
                                         script = SMTScript {scriptBody = unlines (solverTweaks cfg') ++ pgm, scriptModel = Nothing}
                                     standardSolver cfg' script id (ProofError cfg') (interpretSolverOutput cfg' (extractMap (map snd qinps) modelMap))

--- a/Data/SBV/Provers/Z3.hs
+++ b/Data/SBV/Provers/Z3.hs
@@ -26,6 +26,7 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum
 import Data.SBV.SMT.SMT
 import Data.SBV.SMT.SMTLib
+import Data.SBV.Utils.Lib (splitArgs)
 
 -- Choose the correct prefix character for passing options
 -- TBD: Is there a more foolproof way of determining this?
@@ -43,8 +44,8 @@ z3 = SMTSolver {
          , executable     = "z3"
          , options        = map (optionPrefix:) ["in", "smt2"]
          , engine         = \cfg isSat qinps modelMap skolemMap pgm -> do
-                                    execName <-               getEnv "SBV_Z3"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
-                                    execOpts <- (words `fmap` getEnv "SBV_Z3_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
+                                    execName <-                   getEnv "SBV_Z3"          `C.catch` (\(_ :: C.SomeException) -> return (executable (solver cfg)))
+                                    execOpts <- (splitArgs `fmap` getEnv "SBV_Z3_OPTIONS") `C.catch` (\(_ :: C.SomeException) -> return (options (solver cfg)))
                                     let cfg' = cfg { solver = (solver cfg) {executable = execName, options = addTimeOut (timeOut cfg) execOpts} }
                                         tweaks = case solverTweaks cfg' of
                                                    [] -> ""

--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -35,6 +35,7 @@ import Data.Typeable
 import Data.SBV.BitVectors.AlgReals
 import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum
+import Data.SBV.Utils.Lib (joinArgs)
 import Data.SBV.Utils.TDiff
 
 -- | Extract the final configuration from a result
@@ -401,7 +402,7 @@ pipeProcess cfg execName opts script cleanErrs = do
                                                                         _                  -> 0 -- can happen if ExitSuccess but there is output on stderr
                                                         in return $ Left $  "Failed to complete the call to " ++ nm
                                                                          ++ "\nExecutable   : " ++ show execPath
-                                                                         ++ "\nOptions      : " ++ unwords opts
+                                                                         ++ "\nOptions      : " ++ joinArgs opts
                                                                          ++ "\nExit code    : " ++ show finalEC
                                                                          ++ "\nSolver output: "
                                                                          ++ "\n" ++ line ++ "\n"
@@ -421,7 +422,7 @@ standardSolver config script cleanErrs failure success = do
         opts     = options smtSolver
         isTiming = timing config
         nmSolver = show (name smtSolver)
-    msg $ "Calling: " ++ show (unwords (exec:opts))
+    msg $ "Calling: " ++ show (unwords (exec:[joinArgs opts]))
     case smtFile config of
       Nothing -> return ()
       Just f  -> do msg $ "Saving the generated script in file: " ++ show f

--- a/Data/SBV/Utils/Lib.hs
+++ b/Data/SBV/Utils/Lib.hs
@@ -9,7 +9,7 @@
 -- Misc helpers
 -----------------------------------------------------------------------------
 
-module Data.SBV.Utils.Lib where
+module Data.SBV.Utils.Lib (mlift2, mlift3, mlift4, mlift5, mlift6, mlift7, mlift8, joinArgs, splitArgs) where
 
 import Data.Char (isSpace)
 import Data.Maybe (fromJust, isNothing)

--- a/Data/SBV/Utils/Lib.hs
+++ b/Data/SBV/Utils/Lib.hs
@@ -11,6 +11,9 @@
 
 module Data.SBV.Utils.Lib where
 
+import Data.Char (isSpace)
+import Data.Maybe (fromJust, isNothing)
+
 -- | Monadic lift over 2-tuples
 mlift2 :: Monad m => (a' -> b' -> r) -> (a -> m a') -> (b -> m b') -> (a, b) -> m r
 mlift2 k f g (a, b) = f a >>= \a' -> g b >>= \b' -> return $ k a' b'
@@ -38,3 +41,55 @@ mlift7 k f g h i j l m (a, b, c, d, e, y, z) = f a >>= \a' -> g b >>= \b' -> h c
 -- | Monadic lift over 8-tuples
 mlift8 :: Monad m => (a' -> b' -> c' -> d' -> e' -> f' -> g' -> h' -> r) -> (a -> m a') -> (b -> m b') -> (c -> m c') -> (d -> m d') -> (e -> m e') -> (f -> m f') -> (g -> m g') -> (h -> m h') -> (a, b, c, d, e, f, g, h) -> m r
 mlift8 k f g h i j l m n (a, b, c, d, e, y, z, w) = f a >>= \a' -> g b >>= \b' -> h c >>= \c' -> i d >>= \d' -> j e >>= \e' -> l y >>= \y' -> m z >>= \z' -> n w >>= \w' -> return $ k a' b' c' d' e' y' z' w'
+
+-- Command line argument parsing code courtesy of Neil Mitchell's
+-- cmdargs package: see
+-- <https://github.com/ndmitchell/cmdargs/blob/master/System/Console/CmdArgs/Explicit/SplitJoin.hs>
+
+-- | Given a sequence of arguments, join them together in a manner that could be used on
+--   the command line, giving preference to the Windows @cmd@ shell quoting conventions.
+--
+--   For an alternative version, intended for actual running the result in a shell, see "System.Process.showCommandForUser"
+joinArgs :: [String] -> String
+joinArgs = unwords . map f
+    where
+        f x = q ++ g x ++ q
+            where
+                hasSpace = any isSpace x
+                q = ['\"' | hasSpace || null x]
+
+                g ('\\':'\"':xs) = '\\':'\\':'\\':'\"': g xs
+                g "\\" | hasSpace = "\\\\"
+                g ('\"':xs) = '\\':'\"': g xs
+                g (x':xs) = x' : g xs
+                g [] = []
+
+
+data State = Init -- either I just started, or just emitted something
+           | Norm -- I'm seeing characters
+           | Quot -- I've seen a quote
+
+-- | Given a string, split into the available arguments. The inverse of 'joinArgs'.
+splitArgs :: String -> [String]
+splitArgs = join . f Init
+    where
+        -- Nothing is start a new string
+        -- Just x is accumulate onto the existing string
+        join :: [Maybe Char] -> [String]
+        join [] = []
+        join xs = map fromJust a : join (drop 1 b)
+            where (a,b) = break isNothing xs
+
+        f Init (x:xs) | isSpace x = f Init xs
+        f Init "\"\"" = [Nothing]
+        f Init "\"" = [Nothing]
+        f Init xs = f Norm xs
+        f m ('\"':'\"':'\"':xs) = Just '\"' : f m xs
+        f m ('\\':'\"':xs) = Just '\"' : f m xs
+        f m ('\\':'\\':'\"':xs) = Just '\\' : f m ('\"':xs)
+        f Norm ('\"':xs) = f Quot xs
+        f Quot ('\"':'\"':xs) = Just '\"' : f Norm xs
+        f Quot ('\"':xs) = f Norm xs
+        f Norm (x:xs) | isSpace x = Nothing : f Init xs
+        f m (x:xs) = Just x : f m xs
+        f _ [] = []


### PR DESCRIPTION
Adapted some code from the `cmdargs` library to treat quoted sequences
as individual arguments. For example:

```
λ> splitArgs "-S \"blast; foo; bar -s\""
["-S","blast; foo; bar -s"]
```