### PR TITLE
Make SBV loadable in ghci by forcing HLint annotations to be Strings

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -825,4 +825,4 @@ Note that the result is properly typed as @X@ elements; these are not mere strin
 elements of the domain and program further with those values as usual.
 -}
 
-{-# ANN module "HLint: ignore Use import/export shortcut" #-}
+{-# ANN module ("HLint: ignore Use import/export shortcut" :: String) #-}

--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -1892,5 +1892,5 @@ slet x f = SBV k $ Right $ cache r
 __unused :: a
 __unused = error "__unused" (isVacuous :: SBool -> IO Bool) (prove :: SBool -> IO ThmResult)
 
-{-# ANN module "HLint: ignore Eta reduce"         #-}
-{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN module ("HLint: ignore Eta reduce" :: String)        #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String)#-}

--- a/Data/SBV/BitVectors/Rounding.hs
+++ b/Data/SBV/BitVectors/Rounding.hs
@@ -72,4 +72,4 @@ instance RoundingFloat Float
 -- | SDouble instance
 instance RoundingFloat Double
 
-{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}

--- a/Data/SBV/Examples/BitPrecise/Legato.hs
+++ b/Data/SBV/Examples/BitPrecise/Legato.hs
@@ -302,5 +302,5 @@ legatoInC = compileToC Nothing "runLegato" $ do
                 cgOutput "hi" hi
                 cgOutput "lo" lo
 
-{-# ANN legato "HLint: ignore Redundant $"        #-}
-{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN legato ("HLint: ignore Redundant $" :: String)        #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}

--- a/Data/SBV/Examples/BitPrecise/PrefixSum.hs
+++ b/Data/SBV/Examples/BitPrecise/PrefixSum.hs
@@ -303,4 +303,4 @@ scanlTrace n = gen >>= print
   where gen = runSymbolic (True, Nothing) $ do args :: [SWord8] <- mkForallVars n
                                                mapM_ output $ ps (0, (+)) args
 
-{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}

--- a/Data/SBV/Examples/Crypto/AES.hs
+++ b/Data/SBV/Examples/Crypto/AES.hs
@@ -577,5 +577,5 @@ aes128LibComponents = [ ("aes128KeySchedule",  keySchedule)
 cgAES128Library :: IO ()
 cgAES128Library = compileToCLib Nothing "aes128Lib" aes128LibComponents
 
-{-# ANN aesRound    "HLint: ignore Use head" #-}
-{-# ANN aesInvRound "HLint: ignore Use head" #-}
+{-# ANN aesRound    ("HLint: ignore Use head" :: String) #-}
+{-# ANN aesInvRound ("HLint: ignore Use head" :: String) #-}

--- a/Data/SBV/Examples/Existentials/CRCPolynomial.hs
+++ b/Data/SBV/Examples/Existentials/CRCPolynomial.hs
@@ -97,4 +97,4 @@ genPoly hd = do res <- allSat $ do
 findHD4Polynomials :: IO ()
 findHD4Polynomials = genPoly 4
 
-{-# ANN crc_48_16 "HLint: ignore Use camelCase" #-}
+{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}

--- a/Data/SBV/Examples/Puzzles/Counts.hs
+++ b/Data/SBV/Examples/Puzzles/Counts.hs
@@ -80,4 +80,4 @@ counts = do res <- allSat $ puzzle `fmap` mkExistVars 10
                      ++ ", of 8 is " ++ show (ns !! 8)
                      ++ ", of 9 is " ++ show (ns !! 9)
                      ++ "."
-{-# ANN counts "HLint: ignore Use head" #-}
+{-# ANN counts ("HLint: ignore Use head" :: String) #-}

--- a/Data/SBV/SMT/SMTLib.hs
+++ b/Data/SBV/SMT/SMTLib.hs
@@ -121,4 +121,4 @@ interpretSolverModelLine inps line = either err extract (parseSExpr line)
                                                                                    ++ "\n\tParse: " ++  show r
         extract _                                                          = []
 
-{-# ANN interpretSolverModelLine  "HLint: ignore Use elemIndex" #-}
+{-# ANN interpretSolverModelLine  ("HLint: ignore Use elemIndex" :: String) #-}

--- a/SBVUnitTest/Examples/CRC/CCITT.hs
+++ b/SBVUnitTest/Examples/CRC/CCITT.hs
@@ -59,4 +59,4 @@ hw4 = do res <- allSat hw4has84Inhabitants
                                            putStrLn $ "  Sent    : " ++ binS (mkFrame (literal sh, literal sl))
                                            putStrLn $ "  Received: " ++ binS (mkFrame (literal rh, literal rl))
 
-{-# ANN crc_48_16 "HLint: ignore Use camelCase" #-}
+{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}

--- a/SBVUnitTest/Examples/CRC/CCITT_Unidir.hs
+++ b/SBVUnitTest/Examples/CRC/CCITT_Unidir.hs
@@ -57,4 +57,4 @@ ccitHDis3 = print =<< prove (crcUniGood 3)
 ccitHDis4 :: IO ()
 ccitHDis4 = print =<< prove (crcUniGood 4)
 
-{-# ANN crc_48_16 "HLint: ignore Use camelCase" #-}
+{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}

--- a/SBVUnitTest/Examples/CRC/GenPoly.hs
+++ b/SBVUnitTest/Examples/CRC/GenPoly.hs
@@ -72,4 +72,4 @@ genPoly hd = do putStrLn $ "*** Looking for polynomials with HD = " ++ show hd
 findHD3Polynomials :: IO ()
 findHD3Polynomials = genPoly 3
 
-{-# ANN crc_48_16 "HLint: ignore Use camelCase" #-}
+{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}

--- a/SBVUnitTest/Examples/CRC/USB5.hs
+++ b/SBVUnitTest/Examples/CRC/USB5.hs
@@ -48,4 +48,4 @@ usbGood sent16 received16 =
          frameSent     = mkFrame sent
          frameReceived = mkFrame received
 
-{-# ANN crc_11_16 "HLint: ignore Use camelCase" #-}
+{-# ANN crc_11_16 ("HLint: ignore Use camelCase" :: String) #-}

--- a/SBVUnitTest/TestSuite/Basics/ArithSolver.hs
+++ b/SBVUnitTest/TestSuite/Basics/ArithSolver.hs
@@ -327,4 +327,4 @@ fs = nan : -infinity : infinity : 0 : -0 : [-5.0, -4.1 .. 5] ++ [5]
 
 ds  :: [Double]
 ds = nan : -infinity : infinity : 0 : -0 : [-5.0, -4.1 .. 5] ++ [5]
-{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}


### PR DESCRIPTION
I was getting errors about missing `Data` and `IsString` instances when loading SBV modules with HLint annotations in ghci, but adding `String` annotations to them fixes the problem.