### PR TITLE
Remove some uses of 'unliteral'

### DIFF
--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -1057,15 +1057,12 @@ class (HasKind a, Ord a) => SymWord a where
   isSymbolic :: SBV a -> Bool
   -- | Does it concretely satisfy the given predicate?
   isConcretely :: SBV a -> (a -> Bool) -> Bool
-  -- | max/minbounds, if available. Note that we don't want
-  -- to impose "Bounded" on our class as Integer is not Bounded but it is a SymWord
-  mbMaxBound, mbMinBound :: Maybe a
   -- | One stop allocator
   mkSymWord :: Maybe Quantifier -> Maybe String -> Symbolic (SBV a)
 
   -- minimal complete definition:: Nothing.
   -- Giving no instances is ok when defining an uninterpreted/enumerated sort, but otherwise you really
-  -- want to define: mbMaxBound, mbMinBound, literal, fromCW, mkSymWord
+  -- want to define: literal, fromCW, mkSymWord
   forall   = mkSymWord (Just ALL) . Just
   forall_  = mkSymWord (Just ALL)   Nothing
   exists   = mkSymWord (Just EX)  . Just
@@ -1085,9 +1082,6 @@ class (HasKind a, Ord a) => SymWord a where
   isConcretely s p
     | Just i <- unliteral s = p i
     | True                  = False
-  -- Followings, you really want to define them unless the instance is for an uninterpreted/enumerated sort
-  mbMaxBound = Nothing
-  mbMinBound = Nothing
 
   default literal :: Show a => a -> SBV a
   literal x = let k@(KUserSort  _ (conts, _)) = kindOf x

--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -149,71 +149,51 @@ instance SymWord Bool where
   mkSymWord  = genMkSymVar KBool
   literal x  = genLiteral  KBool (if x then (1::Integer) else 0)
   fromCW     = cwToBool
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Word8 where
   mkSymWord  = genMkSymVar (KBounded False 8)
   literal    = genLiteral  (KBounded False 8)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Int8 where
   mkSymWord  = genMkSymVar (KBounded True 8)
   literal    = genLiteral  (KBounded True 8)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Word16 where
   mkSymWord  = genMkSymVar (KBounded False 16)
   literal    = genLiteral  (KBounded False 16)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Int16 where
   mkSymWord  = genMkSymVar (KBounded True 16)
   literal    = genLiteral  (KBounded True 16)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Word32 where
   mkSymWord  = genMkSymVar (KBounded False 32)
   literal    = genLiteral  (KBounded False 32)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Int32 where
   mkSymWord  = genMkSymVar (KBounded True 32)
   literal    = genLiteral  (KBounded True 32)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Word64 where
   mkSymWord  = genMkSymVar (KBounded False 64)
   literal    = genLiteral  (KBounded False 64)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Int64 where
   mkSymWord  = genMkSymVar (KBounded True 64)
   literal    = genLiteral  (KBounded True 64)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 instance SymWord Integer where
   mkSymWord  = genMkSymVar KUnbounded
   literal    = SBV KUnbounded . Left . mkConstCW KUnbounded
   fromCW     = genFromCW
-  mbMaxBound = Nothing
-  mbMinBound = Nothing
 
 instance SymWord AlgReal where
   mkSymWord  = genMkSymVar KReal
@@ -225,8 +205,6 @@ instance SymWord AlgReal where
   isConcretely (SBV KReal (Left (CW KReal (CWAlgReal v)))) p
      | isExactRational v = p v
   isConcretely _ _       = False
-  mbMaxBound = Nothing
-  mbMinBound = Nothing
 
 instance SymWord Float where
   mkSymWord  = genMkSymVar KFloat
@@ -237,8 +215,6 @@ instance SymWord Float where
   -- this function is used for optimizations when only one of the argument is concrete,
   -- and in the presence of NaN's it would be incorrect to do any optimization
   isConcretely _ _ = False
-  mbMaxBound = Nothing
-  mbMinBound = Nothing
 
 instance SymWord Double where
   mkSymWord  = genMkSymVar KDouble
@@ -249,8 +225,6 @@ instance SymWord Double where
   -- this function is used for optimizations when only one of the argument is concrete,
   -- and in the presence of NaN's it would be incorrect to do any optimization
   isConcretely _ _ = False
-  mbMaxBound = Nothing
-  mbMinBound = Nothing
 
 ------------------------------------------------------------------------------------
 -- * Smart constructors for creating symbolic values. These are not strictly

--- a/Data/SBV/Examples/Misc/Word4.hs
+++ b/Data/SBV/Examples/Misc/Word4.hs
@@ -117,8 +117,6 @@ instance SymWord Word4 where
   mkSymWord  = genMkSymVar (KBounded False 4)
   literal    = genLiteral  (KBounded False 4)
   fromCW     = genFromCW
-  mbMaxBound = Just maxBound
-  mbMinBound = Just minBound
 
 -- | HasKind instance; simply returning the underlying kind for the type
 instance HasKind Word4 where


### PR DESCRIPTION
These uses of `unliteral :: SBV a -> a` and equality on type `a` were causing errors in our SAW tools, due to our non-standard usage of the `SymWord` class.

The revised definitions are also a step towards implementing #124.