### PR TITLE
Dynamic

### DIFF
--- a/Data/SBV/BitVectors/Concrete.hs
+++ b/Data/SBV/BitVectors/Concrete.hs
@@ -1,0 +1,161 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.BitVectors.Concrete
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Operations on concrete values
+-----------------------------------------------------------------------------
+
+module Data.SBV.BitVectors.Concrete
+  ( module Data.SBV.BitVectors.Concrete
+  ) where
+
+import Data.SBV.BitVectors.Kind
+import Data.SBV.BitVectors.AlgReals
+
+-- | A constant value
+data CWVal = CWAlgReal  AlgReal              -- ^ algebraic real
+           | CWInteger  Integer              -- ^ bit-vector/unbounded integer
+           | CWFloat    Float                -- ^ float
+           | CWDouble   Double               -- ^ double
+           | CWUserSort (Maybe Int, String)  -- ^ value of an uninterpreted/user kind. The Maybe Int shows index position for enumerations
+
+-- We cannot simply derive Eq/Ord for CWVal, since CWAlgReal doesn't have proper
+-- instances for these when values are infinitely precise reals. However, we do
+-- need a structural eq/ord for Map indexes; so define custom ones here:
+instance Eq CWVal where
+  CWAlgReal a  == CWAlgReal b       = a `algRealStructuralEqual` b
+  CWInteger a  == CWInteger b       = a == b
+  CWUserSort a == CWUserSort b = a == b
+  CWFloat a    == CWFloat b         = a == b
+  CWDouble a   == CWDouble b        = a == b
+  _            == _                 = False
+
+instance Ord CWVal where
+  CWAlgReal a `compare` CWAlgReal b   = a `algRealStructuralCompare` b
+  CWAlgReal _ `compare` CWInteger _   = LT
+  CWAlgReal _ `compare` CWFloat _     = LT
+  CWAlgReal _ `compare` CWDouble _    = LT
+  CWAlgReal _ `compare` CWUserSort _  = LT
+
+  CWInteger _ `compare` CWAlgReal _   = GT
+  CWInteger a `compare` CWInteger b   = a `compare` b
+  CWInteger _ `compare` CWFloat _     = LT
+  CWInteger _ `compare` CWDouble _    = LT
+  CWInteger _ `compare` CWUserSort _  = LT
+
+  CWFloat _   `compare` CWAlgReal _   = GT
+  CWFloat _   `compare` CWInteger _   = GT
+  CWFloat a   `compare` CWFloat b     = a `compare` b
+  CWFloat _   `compare` CWDouble _    = LT
+  CWFloat _   `compare` CWUserSort _  = LT
+
+  CWDouble _  `compare` CWAlgReal _   = GT
+  CWDouble _  `compare` CWInteger _   = GT
+  CWDouble _  `compare` CWFloat _     = GT
+  CWDouble a  `compare` CWDouble b    = a `compare` b
+  CWDouble _  `compare` CWUserSort _  = LT
+
+  CWUserSort _ `compare` CWAlgReal _  = GT
+  CWUserSort _ `compare` CWInteger _  = GT
+  CWUserSort _ `compare` CWFloat _    = GT
+  CWUserSort _ `compare` CWDouble _   = GT
+  CWUserSort a `compare` CWUserSort b = a `compare` b
+
+-- | 'CW' represents a concrete word of a fixed size:
+-- Endianness is mostly irrelevant (see the 'FromBits' class).
+-- For signed words, the most significant digit is considered to be the sign.
+data CW = CW { cwKind   :: !Kind
+             , cwVal    :: !CWVal
+             }
+        deriving (Eq, Ord)
+
+-- | Are two CW's of the same type?
+cwSameType :: CW -> CW -> Bool
+cwSameType x y = cwKind x == cwKind y
+
+-- | Is this a bit?
+cwIsBit :: CW -> Bool
+cwIsBit x = case cwKind x of
+              KBool -> True
+              _     -> False
+
+-- | Convert a CW to a Haskell boolean (NB. Assumes input is well-kinded)
+cwToBool :: CW -> Bool
+cwToBool x = cwVal x /= CWInteger 0
+
+-- | Normalize a CW. Essentially performs modular arithmetic to make sure the
+-- value can fit in the given bit-size. Note that this is rather tricky for
+-- negative values, due to asymmetry. (i.e., an 8-bit negative number represents
+-- values in the range -128 to 127; thus we have to be careful on the negative side.)
+normCW :: CW -> CW
+normCW c@(CW (KBounded signed sz) (CWInteger v)) = c { cwVal = CWInteger norm }
+ where norm | sz == 0 = 0
+            | signed  = let rg = 2 ^ (sz - 1)
+                        in case divMod v rg of
+                                  (a, b) | even a -> b
+                                  (_, b)          -> b - rg
+            | True    = v `mod` (2 ^ sz)
+normCW c = c
+
+-- | Constant False as a CW. We represent it using the integer value 0.
+falseCW :: CW
+falseCW = CW KBool (CWInteger 0)
+
+-- | Constant True as a CW. We represent it using the integer value 1.
+trueCW :: CW
+trueCW  = CW KBool (CWInteger 1)
+
+-- | Lift a unary function thruough a CW
+liftCW :: (AlgReal -> b) -> (Integer -> b) -> (Float -> b) -> (Double -> b) -> ((Maybe Int, String) -> b) -> CW -> b
+liftCW f _ _ _ _ (CW _ (CWAlgReal v))  = f v
+liftCW _ f _ _ _ (CW _ (CWInteger v))  = f v
+liftCW _ _ f _ _ (CW _ (CWFloat v))    = f v
+liftCW _ _ _ f _ (CW _ (CWDouble v))   = f v
+liftCW _ _ _ _ f (CW _ (CWUserSort v)) = f v
+
+-- | Lift a binary function through a CW
+liftCW2 :: (AlgReal -> AlgReal -> b) -> (Integer -> Integer -> b) -> (Float -> Float -> b) -> (Double -> Double -> b) -> ((Maybe Int, String) -> (Maybe Int, String) -> b) -> CW -> CW -> b
+liftCW2 r i f d u x y = case (cwVal x, cwVal y) of
+                         (CWAlgReal a,  CWAlgReal b)  -> r a b
+                         (CWInteger a,  CWInteger b)  -> i a b
+                         (CWFloat a,    CWFloat b)    -> f a b
+                         (CWDouble a,   CWDouble b)   -> d a b
+                         (CWUserSort a, CWUserSort b) -> u a b
+                         _                            -> error $ "SBV.liftCW2: impossible, incompatible args received: " ++ show (x, y)
+
+-- | Map a unary function through a CW
+mapCW :: (AlgReal -> AlgReal) -> (Integer -> Integer) -> (Float -> Float) -> (Double -> Double) -> ((Maybe Int, String) -> (Maybe Int, String)) -> CW -> CW
+mapCW r i f d u x  = normCW $ CW (cwKind x) $ case cwVal x of
+                                               CWAlgReal a  -> CWAlgReal  (r a)
+                                               CWInteger a  -> CWInteger  (i a)
+                                               CWFloat a    -> CWFloat    (f a)
+                                               CWDouble a   -> CWDouble   (d a)
+                                               CWUserSort a -> CWUserSort (u a)
+
+-- | Map a binary function through a CW
+mapCW2 :: (AlgReal -> AlgReal -> AlgReal) -> (Integer -> Integer -> Integer) -> (Float -> Float -> Float) -> (Double -> Double -> Double) -> ((Maybe Int, String) -> (Maybe Int, String) -> (Maybe Int, String)) -> CW -> CW -> CW
+mapCW2 r i f d u x y = case (cwSameType x y, cwVal x, cwVal y) of
+                        (True, CWAlgReal a,  CWAlgReal b)  -> normCW $ CW (cwKind x) (CWAlgReal  (r a b))
+                        (True, CWInteger a,  CWInteger b)  -> normCW $ CW (cwKind x) (CWInteger  (i a b))
+                        (True, CWFloat a,    CWFloat b)    -> normCW $ CW (cwKind x) (CWFloat    (f a b))
+                        (True, CWDouble a,   CWDouble b)   -> normCW $ CW (cwKind x) (CWDouble   (d a b))
+                        (True, CWUserSort a, CWUserSort b) -> normCW $ CW (cwKind x) (CWUserSort (u a b))
+                        _                                  -> error $ "SBV.mapCW2: impossible, incompatible args received: " ++ show (x, y)
+
+instance Show CW where
+  show w | cwIsBit w = show (cwToBool w)
+  show w             = liftCW show show show show snd w ++ " :: " ++ show (cwKind w)
+
+-- | Create a constant word from an integral
+mkConstCW :: Integral a => Kind -> a -> CW
+mkConstCW KBool           a = normCW $ CW KBool      (CWInteger (toInteger a))
+mkConstCW k@(KBounded{})  a = normCW $ CW k          (CWInteger (toInteger a))
+mkConstCW KUnbounded      a = normCW $ CW KUnbounded (CWInteger (toInteger a))
+mkConstCW KReal           a = normCW $ CW KReal      (CWAlgReal (fromInteger (toInteger a)))
+mkConstCW KFloat          a = normCW $ CW KFloat     (CWFloat   (fromInteger (toInteger a)))
+mkConstCW KDouble         a = normCW $ CW KDouble    (CWDouble  (fromInteger (toInteger a)))
+mkConstCW (KUserSort s _) a = error $ "Unexpected call to mkConstCW with uninterpreted kind: " ++ s ++ " with value: " ++ show (toInteger a)

--- a/Data/SBV/BitVectors/Concrete.hs
+++ b/Data/SBV/BitVectors/Concrete.hs
@@ -13,6 +13,7 @@ module Data.SBV.BitVectors.Concrete
   ( module Data.SBV.BitVectors.Concrete
   ) where
 
+import Data.Bits
 import System.Random (randomIO, randomRIO)
 
 import Data.SBV.BitVectors.Kind
@@ -101,6 +102,7 @@ normCW c@(CW (KBounded signed sz) (CWInteger v)) = c { cwVal = CWInteger norm }
                                   (a, b) | even a -> b
                                   (_, b)          -> b - rg
             | True    = v `mod` (2 ^ sz)
+normCW c@(CW KBool (CWInteger v)) = c { cwVal = CWInteger (v .&. 1) }
 normCW c = c
 
 -- | Constant False as a CW. We represent it using the integer value 0.

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -77,83 +77,7 @@ import Data.SBV.Utils.Lib
 
 import Data.SBV.BitVectors.Kind
 import Data.SBV.BitVectors.Concrete
-
--- | A symbolic node id
-newtype NodeId = NodeId Int deriving (Eq, Ord)
-
--- | A symbolic word, tracking it's signedness and size.
-data SW = SW Kind NodeId deriving (Eq, Ord)
-
--- | Forcing an argument; this is a necessary evil to make sure all the arguments
--- to an uninterpreted function and sBranch test conditions are evaluated before called;
--- the semantics of uinterpreted functions is necessarily strict; deviating from Haskell's
-forceSWArg :: SW -> IO ()
-forceSWArg (SW k n) = k `seq`  n `seq` return ()
-
--- | Quantifiers: forall or exists. Note that we allow
--- arbitrary nestings.
-data Quantifier = ALL | EX deriving Eq
-
--- | Are there any existential quantifiers?
-needsExistentials :: [Quantifier] -> Bool
-needsExistentials = (EX `elem`)
-
--- | Constant False as a SW. Note that this value always occupies slot -2.
-falseSW :: SW
-falseSW = SW KBool $ NodeId (-2)
-
--- | Constant False as a SW. Note that this value always occupies slot -1.
-trueSW :: SW
-trueSW  = SW KBool $ NodeId (-1)
-
--- | A simple type for SBV computations, used mainly for uninterpreted constants.
--- We keep track of the signedness/size of the arguments. A non-function will
--- have just one entry in the list.
-newtype SBVType = SBVType [Kind]
-             deriving (Eq, Ord)
-
--- | how many arguments does the type take?
-typeArity :: SBVType -> Int
-typeArity (SBVType xs) = length xs - 1
-
-instance Show SBVType where
-  show (SBVType []) = error "SBV: internal error, empty SBVType"
-  show (SBVType xs) = intercalate " -> " $ map show xs
-
--- | Symbolic operations
-data Op = Plus | Times | Minus | UNeg | Abs
-        | Quot | Rem
-        | Equal | NotEqual
-        | LessThan | GreaterThan | LessEq | GreaterEq
-        | Ite
-        | And | Or  | XOr | Not
-        | Shl Int | Shr Int | Rol Int | Ror Int
-        | Extract Int Int -- Extract i j: extract bits i to j. Least significant bit is 0 (big-endian)
-        | Join  -- Concat two words to form a bigger one, in the order given
-        | LkUp (Int, Kind, Kind, Int) !SW !SW   -- (table-index, arg-type, res-type, length of the table) index out-of-bounds-value
-        | ArrEq   Int Int
-        | ArrRead Int
-        | Uninterpreted String
-        -- Floating point uops with custom rounding-modes
-        | FPRound String
-        deriving (Eq, Ord)
-
--- | SMT-Lib's square-root over floats/doubles. We piggy back on to the uninterpreted function mechanism
--- to implement these; which is not a terrible idea; although the use of the constructor 'Uninterpreted'
--- might be confusing. This function will *not* be uninterpreted in reality, as QF_FP will define it. It's
--- a bit of a shame, but much easier to implement it this way.
-smtLibSquareRoot :: Op
-smtLibSquareRoot = Uninterpreted "fp.sqrt"
-
--- | SMT-Lib's fusedMA over floats/doubles. Similar to the 'smtLibSquareRoot'. Note that we cannot implement
--- this function in Haskell as precision loss would be inevitable. Maybe Haskell will eventually add this op
--- to the Num class.
-smtLibFusedMA :: Op
-smtLibFusedMA = Uninterpreted "fp.fma"
-
--- | A symbolic expression
-data SBVExpr = SBVApp !Op ![SW]
-             deriving (Eq, Ord)
+import Data.SBV.BitVectors.Symbolic
 
 -- | A class for capturing values that have a sign and a size (finite or infinite)
 -- minimal complete definition: kindOf. This class can be automatically derived
@@ -228,251 +152,17 @@ instance HasKind CW where
 instance HasKind SW where
   kindOf (SW k _) = k
 
-instance Show SW where
-  show (SW _ (NodeId n))
-    | n < 0 = "s_" ++ show (abs n)
-    | True  = 's' : show n
-
-instance Show Op where
-  show (Shl i) = "<<"  ++ show i
-  show (Shr i) = ">>"  ++ show i
-  show (Rol i) = "<<<" ++ show i
-  show (Ror i) = ">>>" ++ show i
-  show (Extract i j) = "choose [" ++ show i ++ ":" ++ show j ++ "]"
-  show (LkUp (ti, at, rt, l) i e)
-        = "lookup(" ++ tinfo ++ ", " ++ show i ++ ", " ++ show e ++ ")"
-        where tinfo = "table" ++ show ti ++ "(" ++ show at ++ " -> " ++ show rt ++ ", " ++ show l ++ ")"
-  show (ArrEq i j)   = "array_" ++ show i ++ " == array_" ++ show j
-  show (ArrRead i)   = "select array_" ++ show i
-  show (Uninterpreted i) = "[uninterpreted] " ++ i
-  show (FPRound w)       = w
-  show op
-    | Just s <- op `lookup` syms = s
-    | True                       = error "impossible happened; can't find op!"
-    where syms = [ (Plus, "+"), (Times, "*"), (Minus, "-"), (UNeg, "-"), (Abs, "abs")
-                 , (Quot, "quot")
-                 , (Rem,  "rem")
-                 , (Equal, "=="), (NotEqual, "/=")
-                 , (LessThan, "<"), (GreaterThan, ">"), (LessEq, "<"), (GreaterEq, ">")
-                 , (Ite, "if_then_else")
-                 , (And, "&"), (Or, "|"), (XOr, "^"), (Not, "~")
-                 , (Join, "#")
-                 ]
-
--- | To improve hash-consing, take advantage of commutative operators by
--- reordering their arguments.
-reorder :: SBVExpr -> SBVExpr
-reorder s = case s of
-              SBVApp op [a, b] | isCommutative op && a > b -> SBVApp op [b, a]
-              _ -> s
-  where isCommutative :: Op -> Bool
-        isCommutative o = o `elem` [Plus, Times, Equal, NotEqual, And, Or, XOr]
-
-instance Show SBVExpr where
-  show (SBVApp Ite [t, a, b]) = unwords ["if", show t, "then", show a, "else", show b]
-  show (SBVApp (Shl i) [a])   = unwords [show a, "<<", show i]
-  show (SBVApp (Shr i) [a])   = unwords [show a, ">>", show i]
-  show (SBVApp (Rol i) [a])   = unwords [show a, "<<<", show i]
-  show (SBVApp (Ror i) [a])   = unwords [show a, ">>>", show i]
-  show (SBVApp op  [a, b])    = unwords [show a, show op, show b]
-  show (SBVApp op  args)      = unwords (show op : map show args)
-
--- | A program is a sequence of assignments
-newtype SBVPgm = SBVPgm {pgmAssignments :: (S.Seq (SW, SBVExpr))}
-
--- | 'NamedSymVar' pairs symbolic words and user given/automatically generated names
-type NamedSymVar = (SW, String)
-
--- | 'UnintKind' pairs array names and uninterpreted constants with their "kinds"
--- used mainly for printing counterexamples
-data UnintKind = UFun Int String | UArr Int String      -- in each case, arity and the aliasing name
- deriving Show
-
--- | Result of running a symbolic computation
-data Result = Result (Set.Set Kind)                -- kinds used in the program
-                     [(String, CW)]                -- quick-check counter-example information (if any)
-                     [(String, [String])]          -- uninterpeted code segments
-                     [(Quantifier, NamedSymVar)]   -- inputs (possibly existential)
-                     [(SW, CW)]                    -- constants
-                     [((Int, Kind, Kind), [SW])]   -- tables (automatically constructed) (tableno, index-type, result-type) elts
-                     [(Int, ArrayInfo)]            -- arrays (user specified)
-                     [(String, SBVType)]           -- uninterpreted constants
-                     [(String, [String])]          -- axioms
-                     SBVPgm                        -- assignments
-                     [SW]                          -- additional constraints (boolean)
-                     [SW]                          -- outputs
-
--- | Extract the constraints from a result
-getConstraints :: Result -> [SW]
-getConstraints (Result _ _ _ _ _ _ _ _ _ _ cstrs _) = cstrs
-
--- | Extract the traced-values from a result (quick-check)
-getTraceInfo :: Result -> [(String, CW)]
-getTraceInfo (Result _ tvals _ _ _ _ _ _ _ _ _ _) = tvals
-
-instance Show Result where
-  show (Result _ _ _ _ cs _ _ [] [] _ [] [r])
-    | Just c <- r `lookup` cs
-    = show c
-  show (Result kinds _ cgs is cs ts as uis axs xs cstrs os)  = intercalate "\n" $
-                   (if null usorts then [] else "SORTS" : map ("  " ++) usorts)
-                ++ ["INPUTS"]
-                ++ map shn is
-                ++ ["CONSTANTS"]
-                ++ map shc cs
-                ++ ["TABLES"]
-                ++ map sht ts
-                ++ ["ARRAYS"]
-                ++ map sha as
-                ++ ["UNINTERPRETED CONSTANTS"]
-                ++ map shui uis
-                ++ ["USER GIVEN CODE SEGMENTS"]
-                ++ concatMap shcg cgs
-                ++ ["AXIOMS"]
-                ++ map shax axs
-                ++ ["DEFINE"]
-                ++ map (\(s, e) -> "  " ++ shs s ++ " = " ++ show e) (F.toList (pgmAssignments xs))
-                ++ ["CONSTRAINTS"]
-                ++ map (("  " ++) . show) cstrs
-                ++ ["OUTPUTS"]
-                ++ map (("  " ++) . show) os
-    where usorts = [sh s t | KUserSort s t <- Set.toList kinds]
-                   where sh s (Left   _, _) = s
-                         sh s (Right es, _) = s ++ " (" ++ intercalate ", " es ++ ")"
-          shs sw = show sw ++ " :: " ++ showType sw
-          sht ((i, at, rt), es)  = "  Table " ++ show i ++ " : " ++ show at ++ "->" ++ show rt ++ " = " ++ show es
-          shc (sw, cw) = "  " ++ show sw ++ " = " ++ show cw
-          shcg (s, ss) = ("Variable: " ++ s) : map ("  " ++) ss
-          shn (q, (sw, nm)) = "  " ++ ni ++ " :: " ++ showType sw ++ ex ++ alias
-            where ni = show sw
-                  ex | q == ALL = ""
-                     | True     = ", existential"
-                  alias | ni == nm = ""
-                        | True     = ", aliasing " ++ show nm
-          sha (i, (nm, (ai, bi), ctx)) = "  " ++ ni ++ " :: " ++ show ai ++ " -> " ++ show bi ++ alias
-                                       ++ "\n     Context: "     ++ show ctx
-            where ni = "array_" ++ show i
-                  alias | ni == nm = ""
-                        | True     = ", aliasing " ++ show nm
-          shui (nm, t) = "  [uninterpreted] " ++ nm ++ " :: " ++ show t
-          shax (nm, ss) = "  -- user defined axiom: " ++ nm ++ "\n  " ++ intercalate "\n  " ss
-
--- | The context of a symbolic array as created
-data ArrayContext = ArrayFree (Maybe SW)     -- ^ A new array, with potential initializer for each cell
-                  | ArrayReset Int SW        -- ^ An array created from another array by fixing each element to another value
-                  | ArrayMutate Int SW SW    -- ^ An array created by mutating another array at a given cell
-                  | ArrayMerge  SW Int Int   -- ^ An array created by symbolically merging two other arrays
-
-instance Show ArrayContext where
-  show (ArrayFree Nothing)  = " initialized with random elements"
-  show (ArrayFree (Just s)) = " initialized with " ++ show s ++ " :: " ++ showType s
-  show (ArrayReset i s)     = " reset array_" ++ show i ++ " with " ++ show s ++ " :: " ++ showType s
-  show (ArrayMutate i a b)  = " cloned from array_" ++ show i ++ " with " ++ show a ++ " :: " ++ showType a ++ " |-> " ++ show b ++ " :: " ++ showType b
-  show (ArrayMerge s i j)   = " merged arrays " ++ show i ++ " and " ++ show j ++ " on condition " ++ show s
-
--- | Expression map, used for hash-consing
-type ExprMap   = Map.Map SBVExpr SW
-
--- | Constants are stored in a map, for hash-consing
-type CnstMap   = Map.Map CW SW
-
--- | Kinds used in the program; used for determining the final SMT-Lib logic to pick
-type KindSet = Set.Set Kind
-
--- | Tables generated during a symbolic run
-type TableMap  = Map.Map [SW] (Int, Kind, Kind)
-
--- | Representation for symbolic arrays
-type ArrayInfo = (String, (Kind, Kind), ArrayContext)
-
--- | Arrays generated during a symbolic run
-type ArrayMap  = IMap.IntMap ArrayInfo
-
--- | Uninterpreted-constants generated during a symbolic run
-type UIMap     = Map.Map String SBVType
-
--- | Code-segments for Uninterpreted-constants, as given by the user
-type CgMap     = Map.Map String [String]
-
--- | Cached values, implementing sharing
-type Cache a   = IMap.IntMap [(StableName (State -> IO a), a)]
-
--- | Convert an SBV-type to the kind-of uninterpreted value it represents
-unintFnUIKind :: (String, SBVType) -> (String, UnintKind)
-unintFnUIKind (s, t) = (s, UFun (typeArity t) s)
-
--- | Convert an array value type to the kind-of uninterpreted value it represents
-arrayUIKind :: (Int, ArrayInfo) -> Maybe (String, UnintKind)
-arrayUIKind (i, (nm, _, ctx)) 
-  | external ctx = Just ("array_" ++ show i, UArr 1 nm) -- arrays are always 1-dimensional in the SMT-land. (Unless encoded explicitly)
-  | True         = Nothing
-  where external (ArrayFree{})   = True
-        external (ArrayReset{})  = False
-        external (ArrayMutate{}) = False
-        external (ArrayMerge{})  = False
-
--- | Different means of running a symbolic piece of code
-data SBVRunMode = Proof (Bool, Maybe SMTConfig) -- ^ Symbolic simulation mode, for proof purposes. Bool is True if it's a sat instance. SMTConfig is used for 'sBranch' calls.
-                | CodeGen                       -- ^ Code generation mode
-                | Concrete StdGen               -- ^ Concrete simulation mode. The StdGen is for the pConstrain acceptance in cross runs
-
--- | Is this a concrete run? (i.e., quick-check or test-generation like)
-isConcreteMode :: SBVRunMode -> Bool
-isConcreteMode (Concrete _) = True
-isConcreteMode (Proof{})    = False
-isConcreteMode CodeGen      = False
-
--- | The state of the symbolic interpreter
-data State  = State { runMode       :: SBVRunMode
-                    , pathCond      :: SBool
-                    , rStdGen       :: IORef StdGen
-                    , rCInfo        :: IORef [(String, CW)]
-                    , rctr          :: IORef Int
-                    , rUsedKinds    :: IORef KindSet
-                    , rinps         :: IORef [(Quantifier, NamedSymVar)]
-                    , rConstraints  :: IORef [SW]
-                    , routs         :: IORef [SW]
-                    , rtblMap       :: IORef TableMap
-                    , spgm          :: IORef SBVPgm
-                    , rconstMap     :: IORef CnstMap
-                    , rexprMap      :: IORef ExprMap
-                    , rArrayMap     :: IORef ArrayMap
-                    , rUIMap        :: IORef UIMap
-                    , rCgMap        :: IORef CgMap
-                    , raxioms       :: IORef [(String, [String])]
-                    , rSWCache      :: IORef (Cache SW)
-                    , rAICache      :: IORef (Cache Int)
-                    }
-
 -- | Get the current path condition
 getPathCondition :: State -> SBool
-getPathCondition = pathCond
+getPathCondition st = SBV (getSValPathCondition st)
 
 -- | Extend the path condition with the given test value.
 extendPathCondition :: State -> (SBool -> SBool) -> State
-extendPathCondition st f = st{pathCond = f (pathCond st)}
-
--- | Are we running in proof mode?
-inProofMode :: State -> Bool
-inProofMode s = case runMode s of
-                  Proof{}    -> True
-                  CodeGen    -> False
-                  Concrete{} -> False
-
--- | If in proof mode, get the underlying configuration (used for 'sBranch')
-getSBranchRunConfig :: State -> Maybe SMTConfig
-getSBranchRunConfig st = case runMode st of
-                           Proof (_, s)  -> s
-                           _             -> Nothing
-
--- | The "Symbolic" value. Either a constant (@Left@) or a symbolic
--- value (@Right Cached@). Note that caching is essential for making
--- sure sharing is preserved.
-data SVal = SVal !Kind !(Either CW (Cached SW))
+extendPathCondition st f = extendSValPathCondition st (unSBV . f . SBV)
 
 -- | The "Symbolic" value. The parameter 'a' is phantom, but is
 -- extremely important in keeping the user interface strongly typed.
-newtype SBV a = SBV SVal
+newtype SBV a = SBV { unSBV :: SVal }
 
 -- | A symbolic boolean/bit
 type SBool   = SBV Bool
@@ -533,21 +223,6 @@ sNaN = literal nan
 sInfinity :: (Floating a, SymWord a) => SBV a
 sInfinity = literal infinity
 
--- | Rounding mode to be used for the IEEE floating-point operations.
--- Note that Haskell's default is 'RoundNearestTiesToEven'. If you use
--- a different rounding mode, then the counter-examples you get may not
--- match what you observe in Haskell.
-data RoundingMode = RoundNearestTiesToEven  -- ^ Round to nearest representable floating point value.
-                                            -- If precisely at half-way, pick the even number.
-                                            -- (In this context, /even/ means the lowest-order bit is zero.)
-                  | RoundNearestTiesToAway  -- ^ Round to nearest representable floating point value.
-                                            -- If precisely at half-way, pick the number further away from 0.
-                                            -- (That is, for positive values, pick the greater; for negative values, pick the smaller.)
-                  | RoundTowardPositive     -- ^ Round towards positive infinity. (Also known as rounding-up or ceiling.)
-                  | RoundTowardNegative     -- ^ Round towards negative infinity. (Also known as rounding-down or floor.)
-                  | RoundTowardZero         -- ^ Round towards zero. (Also known as truncation.)
-                  deriving (Eq, Ord, G.Data, T.Typeable, Read, Show, Bounded, Enum)
-
 -- | 'RoundingMode' can be used symbolically
 instance SymWord RoundingMode
 
@@ -558,21 +233,11 @@ instance HasKind RoundingMode
 type SRoundingMode = SBV RoundingMode
 
 -- Not particularly "desirable", but will do if needed
-instance Show SVal where
-  show (SVal _ (Left c))  = show c
-  show (SVal k (Right _)) = "<symbolic> :: " ++ show k
-
 instance Show (SBV a) where
   show (SBV sv) = show sv
 
 -- Equality constraint on SBV values. Not desirable since we can't really compare two
 -- symbolic values, but will do.
-instance Eq SVal where
-  SVal _ (Left a) == SVal _ (Left b) = a == b
-  a == b = error $ "Comparing symbolic bit-vectors; Use (.==) instead. Received: " ++ show (a, b)
-  SVal _ (Left a) /= SVal _ (Left b) = a /= b
-  a /= b = error $ "Comparing symbolic bit-vectors; Use (./=) instead. Received: " ++ show (a, b)
-
 instance Eq (SBV a) where
   SBV a == SBV b = a == b
   SBV a /= SBV b = a /= b
@@ -580,130 +245,20 @@ instance Eq (SBV a) where
 instance HasKind a => HasKind (SBV a) where
   kindOf (SBV (SVal k _)) = k
 
--- | Increment the variable counter
-incCtr :: State -> IO Int
-incCtr s = do ctr <- readIORef (rctr s)
-              let i = ctr + 1
-              i `seq` writeIORef (rctr s) i
-              return ctr
-
--- | Generate a random value, for quick-check and test-gen purposes
-throwDice :: State -> IO Double
-throwDice st = do g <- readIORef (rStdGen st)
-                  let (r, g') = randomR (0, 1) g
-                  writeIORef (rStdGen st) g'
-                  return r
-
--- | Create a new uninterpreted symbol, possibly with user given code
-newUninterpreted :: State -> String -> SBVType -> Maybe [String] -> IO ()
-newUninterpreted st nm t mbCode
-  | null nm || not (isAlpha (head nm)) || not (all validChar (tail nm))
-  = error $ "Bad uninterpreted constant name: " ++ show nm ++ ". Must be a valid identifier."
-  | True = do
-        uiMap <- readIORef (rUIMap st)
-        case nm `Map.lookup` uiMap of
-          Just t' -> if t /= t'
-                     then error $  "Uninterpreted constant " ++ show nm ++ " used at incompatible types\n"
-                                ++ "      Current type      : " ++ show t ++ "\n"
-                                ++ "      Previously used at: " ++ show t'
-                     else return ()
-          Nothing -> do modifyIORef (rUIMap st) (Map.insert nm t)
-                        when (isJust mbCode) $ modifyIORef (rCgMap st) (Map.insert nm (fromJust mbCode))
-  where validChar x = isAlphaNum x || x `elem` "_"
-
--- | Create a new SW
-newSW :: State -> Kind -> IO (SW, String)
-newSW st k = do ctr <- incCtr st
-                let sw = SW k (NodeId ctr)
-                registerKind st k
-                return (sw, 's' : show ctr)
-{-# INLINE newSW #-}
-
-registerKind :: State -> Kind -> IO ()
-registerKind st k
-  | KUserSort sortName _ <- k, sortName `elem` reserved
-  = error $ "SBV: " ++ show sortName ++ " is a reserved sort; please use a different name."
-  | True
-  = modifyIORef (rUsedKinds st) (Set.insert k)
- where -- TODO: this list is not comprehensive!
-       reserved = ["Int", "Real", "List", "Array", "Bool", "NUMERAL", "DECIMAL", "STRING", "FP", "FloatingPoint", "fp"]  -- Reserved by SMT-Lib
-
--- | Create a new constant; hash-cons as necessary
-newConst :: State -> CW -> IO SW
-newConst st c = do
-  constMap <- readIORef (rconstMap st)
-  case c `Map.lookup` constMap of
-    Just sw -> return sw
-    Nothing -> do let k = kindOf c
-                  (sw, _) <- newSW st k
-                  modifyIORef (rconstMap st) (Map.insert c sw)
-                  return sw
-{-# INLINE newConst #-}
-
--- | Create a new table; hash-cons as necessary
-getTableIndex :: State -> Kind -> Kind -> [SW] -> IO Int
-getTableIndex st at rt elts = do
-  tblMap <- readIORef (rtblMap st)
-  case elts `Map.lookup` tblMap of
-    Just (i, _, _)  -> return i
-    Nothing         -> do let i = Map.size tblMap
-                          modifyIORef (rtblMap st) (Map.insert elts (i, at, rt))
-                          return i
-
--- | Create a new expression; hash-cons as necessary
-newExpr :: State -> Kind -> SBVExpr -> IO SW
-newExpr st k app = do
-   let e = reorder app
-   exprMap <- readIORef (rexprMap st)
-   case e `Map.lookup` exprMap of
-     Just sw -> return sw
-     Nothing -> do (sw, _) <- newSW st k
-                   modifyIORef (spgm st)     (\(SBVPgm xs) -> SBVPgm (xs S.|> (sw, e)))
-                   modifyIORef (rexprMap st) (Map.insert e sw)
-                   return sw
-{-# INLINE newExpr #-}
-
 -- | Convert a symbolic value to a symbolic-word
 sbvToSW :: State -> SBV a -> IO SW
-sbvToSW st (SBV (SVal _ (Left c)))  = newConst st c
-sbvToSW st (SBV (SVal _ (Right f))) = uncache f st
+sbvToSW st (SBV s) = svToSW st s
 
 -------------------------------------------------------------------------
 -- * Symbolic Computations
 -------------------------------------------------------------------------
--- | A Symbolic computation. Represented by a reader monad carrying the
--- state of the computation, layered on top of IO for creating unique
--- references to hold onto intermediate results.
-newtype Symbolic a = Symbolic (ReaderT State IO a)
-                   deriving (Applicative, Functor, Monad, MonadIO, MonadReader State)
 
 -- | Create a symbolic variable. Equivalent to 'mkSymSBVWithRandom randomIO'.
 mkSymSBV :: forall a. (Random a, SymWord a) => Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
 mkSymSBV = mkSymSBVWithRandom randomIO
 
--- | Create a symbolic value, based on the quantifier we have. If an explicit quantifier is given, we just use that.
--- If not, then we pick existential for SAT calls and universal for everything else. The @rand@ argument is used
--- in generating random values for this variable when used for 'quickCheck' purposes.
 mkSymSBVWithRandom :: forall a. SymWord a => IO (SBV a) -> Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
-mkSymSBVWithRandom rand mbQ k mbNm = do
-        st <- ask
-        let q = case (mbQ, runMode st) of
-                  (Just x,  _)                -> x   -- user given, just take it
-                  (Nothing, Concrete{})       -> ALL -- concrete simulation, pick universal
-                  (Nothing, Proof (True, _))  -> EX  -- sat mode, pick existential
-                  (Nothing, Proof (False, _)) -> ALL -- proof mode, pick universal
-                  (Nothing, CodeGen)          -> ALL -- code generation, pick universal
-        case runMode st of
-          Concrete _ | q == EX -> case mbNm of
-                                    Nothing -> error $ "Cannot quick-check in the presence of existential variables, type: " ++ showType (undefined :: a)
-                                    Just nm -> error $ "Cannot quick-check in the presence of existential variable " ++ nm ++ " :: " ++ showType (undefined :: a)
-          Concrete _           -> do v@(SBV (SVal _ (Left cw))) <- liftIO rand
-                                     liftIO $ modifyIORef (rCInfo st) ((maybe "_" id mbNm, cw):)
-                                     return v
-          _          -> do (sw, internalName) <- liftIO $ newSW st k
-                           let nm = maybe internalName id mbNm
-                           liftIO $ modifyIORef (rinps st) ((q, (sw, nm)):)
-                           return $ SBV $ SVal k $ Right $ cache (const (return sw))
+mkSymSBVWithRandom rand mbQ k mbNm = fmap SBV $ mkSValWithRandom (fmap unSBV rand) mbQ k mbNm
 
 -- | Convert a symbolic value to an SW, inside the Symbolic monad
 sbvToSymSW :: SBV a -> Symbolic SW
@@ -718,15 +273,8 @@ class Outputtable a where
   output :: a -> Symbolic a
 
 instance Outputtable (SBV a) where
-  output i@(SBV (SVal _ (Left c))) = do
-          st <- ask
-          sw <- liftIO $ newConst st c
-          liftIO $ modifyIORef (routs st) (sw:)
-          return i
-  output i@(SBV (SVal _ (Right f))) = do
-          st <- ask
-          sw <- liftIO $ uncache f st
-          liftIO $ modifyIORef (routs st) (sw:)
+  output i = do
+          outputSVal (unSBV i)
           return i
 
 instance Outputtable a => Outputtable [a] where
@@ -755,90 +303,6 @@ instance (Outputtable a, Outputtable b, Outputtable c, Outputtable d, Outputtabl
 
 instance (Outputtable a, Outputtable b, Outputtable c, Outputtable d, Outputtable e, Outputtable f, Outputtable g, Outputtable h) => Outputtable (a, b, c, d, e, f, g, h) where
   output = mlift8 (,,,,,,,) output output output output output output output output
-
--- | Add a user specified axiom to the generated SMT-Lib file. The first argument is a mere
--- string, use for commenting purposes. The second argument is intended to hold the multiple-lines
--- of the axiom text as expressed in SMT-Lib notation. Note that we perform no checks on the axiom
--- itself, to see whether it's actually well-formed or is sensical by any means.
--- A separate formalization of SMT-Lib would be very useful here.
-addAxiom :: String -> [String] -> Symbolic ()
-addAxiom nm ax = do
-        st <- ask
-        liftIO $ modifyIORef (raxioms st) ((nm, ax) :)
-
--- | Run a symbolic computation in Proof mode and return a 'Result'. The boolean
--- argument indicates if this is a sat instance or not.
-runSymbolic :: (Bool, Maybe SMTConfig) -> Symbolic a -> IO Result
-runSymbolic b c = snd `fmap` runSymbolic' (Proof b) c
-
--- | Run a symbolic computation, and return a extra value paired up with the 'Result'
-runSymbolic' :: SBVRunMode -> Symbolic a -> IO (a, Result)
-runSymbolic' currentRunMode (Symbolic c) = do
-   ctr       <- newIORef (-2) -- start from -2; False and True will always occupy the first two elements
-   cInfo     <- newIORef []
-   pgm       <- newIORef (SBVPgm S.empty)
-   emap      <- newIORef Map.empty
-   cmap      <- newIORef Map.empty
-   inps      <- newIORef []
-   outs      <- newIORef []
-   tables    <- newIORef Map.empty
-   arrays    <- newIORef IMap.empty
-   uis       <- newIORef Map.empty
-   cgs       <- newIORef Map.empty
-   axioms    <- newIORef []
-   swCache   <- newIORef IMap.empty
-   aiCache   <- newIORef IMap.empty
-   usedKinds <- newIORef Set.empty
-   cstrs     <- newIORef []
-   rGen      <- case currentRunMode of
-                  Concrete g -> newIORef g
-                  _          -> newStdGen >>= newIORef
-   let st = State { runMode      = currentRunMode
-                  , pathCond     = SBV $ SVal KBool (Left trueCW)
-                  , rStdGen      = rGen
-                  , rCInfo       = cInfo
-                  , rctr         = ctr
-                  , rUsedKinds   = usedKinds
-                  , rinps        = inps
-                  , routs        = outs
-                  , rtblMap      = tables
-                  , spgm         = pgm
-                  , rconstMap    = cmap
-                  , rArrayMap    = arrays
-                  , rexprMap     = emap
-                  , rUIMap       = uis
-                  , rCgMap       = cgs
-                  , raxioms      = axioms
-                  , rSWCache     = swCache
-                  , rAICache     = aiCache
-                  , rConstraints = cstrs
-                  }
-   _ <- newConst st falseCW -- s(-2) == falseSW
-   _ <- newConst st trueCW  -- s(-1) == trueSW
-   r <- runReaderT c st
-   res <- extractSymbolicSimulationState st
-   return (r, res)
-
--- | Grab the program from a running symbolic simulation state. This is useful for internal purposes, for
--- instance when implementing 'sBranch'.
-extractSymbolicSimulationState :: State -> IO Result
-extractSymbolicSimulationState st@State{ spgm=pgm, rinps=inps, routs=outs, rtblMap=tables, rArrayMap=arrays, rUIMap=uis, raxioms=axioms
-                                       , rUsedKinds=usedKinds, rCgMap=cgs, rCInfo=cInfo, rConstraints = cstrs} = do
-   SBVPgm rpgm  <- readIORef pgm
-   inpsO <- reverse `fmap` readIORef inps
-   outsO <- reverse `fmap` readIORef outs
-   let swap (a, b) = (b, a)
-       cmp  (a, _) (b, _) = a `compare` b
-   cnsts <- (sortBy cmp . map swap . Map.toList) `fmap` readIORef (rconstMap st)
-   tbls  <- (sortBy (\((x, _, _), _) ((y, _, _), _) -> x `compare` y) . map swap . Map.toList) `fmap` readIORef tables
-   arrs  <- IMap.toAscList `fmap` readIORef arrays
-   unint <- Map.toList `fmap` readIORef uis
-   axs   <- reverse `fmap` readIORef axioms
-   knds  <- readIORef usedKinds
-   cgMap <- Map.toList `fmap` readIORef cgs
-   traceVals <- reverse `fmap` readIORef cInfo
-   extraCstrs <- reverse `fmap` readIORef cstrs
-   return $ Result knds traceVals cgMap inpsO cnsts tbls arrs unint axs (SBVPgm rpgm) extraCstrs outsO
 
 -------------------------------------------------------------------------------
 -- * Symbolic Words
@@ -921,21 +385,8 @@ class (HasKind a, Ord a) => SymWord a where
   fromCW cw                         = error $ "Cannot convert CW " ++ show cw ++ " to kind " ++ show (kindOf (undefined :: a))
 
   default mkSymWord :: (Read a, G.Data a) => Maybe Quantifier -> Maybe String -> Symbolic (SBV a)
-  mkSymWord mbQ mbNm = do
-        st <- ask
-        let k@(KUserSort sortName _) = constructUKind (undefined :: a)
-        liftIO $ registerKind st k
-        let q = case (mbQ, runMode st) of
-                  (Just x,  _)                -> x
-                  (Nothing, Proof (True, _))  -> EX
-                  (Nothing, Proof (False, _)) -> ALL
-                  (Nothing, Concrete{})       -> error $ "SBV: Uninterpreted sort " ++ sortName ++ " can not be used in concrete simulation mode."
-                  (Nothing, CodeGen)          -> error $ "SBV: Uninterpreted sort " ++ sortName ++ " can not be used in code-generation mode."
-        ctr <- liftIO $ incCtr st
-        let sw = SW k (NodeId ctr)
-            nm = maybe ('s':show ctr) id mbNm
-        liftIO $ modifyIORef (rinps st) ((q, (sw, nm)):)
-        return $ SBV $ SVal k $ Right $ cache (const (return sw))
+  mkSymWord mbQ mbNm = fmap SBV $ mkSValUserSort k mbQ mbNm
+    where k = constructUKind (undefined :: a)
 
 instance (Random a, SymWord a) => Random (SBV a) where
   randomR (l, h) g = case (unliteral l, unliteral h) of
@@ -987,10 +438,7 @@ class SymArray array where
 --
 --   * Typically slower as it heavily relies on SMT-solving for the array theory
 --
-data SArray a b = SArray (Kind, Kind) (Cached ArrayIndex)
-
--- | An array index is simple an int value
-type ArrayIndex = Int
+newtype SArray a b = SArray { unSArray :: SArr }
 
 instance (HasKind a, HasKind b) => Show (SArray a b) where
   show (SArray{}) = "SArray<" ++ showType (undefined :: a) ++ ":" ++ showType (undefined :: b) ++ ">"
@@ -998,48 +446,18 @@ instance (HasKind a, HasKind b) => Show (SArray a b) where
 instance SymArray SArray where
   newArray_  = declNewSArray (\t -> "array_" ++ show t)
   newArray n = declNewSArray (const n)
-  readArray (SArray (_, bk) f) a = SBV $ SVal bk $ Right $ cache r
-     where r st = do arr <- uncacheAI f st
-                     i   <- sbvToSW st a
-                     newExpr st bk (SBVApp (ArrRead arr) [i])
-  resetArray (SArray ainfo f) b = SArray ainfo $ cache g
-     where g st = do amap <- readIORef (rArrayMap st)
-                     val <- sbvToSW st b
-                     i <- uncacheAI f st
-                     let j = IMap.size amap
-                     j `seq` modifyIORef (rArrayMap st) (IMap.insert j ("array_" ++ show j, ainfo, ArrayReset i val))
-                     return j
-  writeArray (SArray ainfo f) a b = SArray ainfo $ cache g
-     where g st = do arr  <- uncacheAI f st
-                     addr <- sbvToSW st a
-                     val  <- sbvToSW st b
-                     amap <- readIORef (rArrayMap st)
-                     let j = IMap.size amap
-                     j `seq` modifyIORef (rArrayMap st) (IMap.insert j ("array_" ++ show j, ainfo, ArrayMutate arr addr val))
-                     return j
-  mergeArrays t (SArray ainfo a) (SArray _ b) = SArray ainfo $ cache h
-    where h st = do ai <- uncacheAI a st
-                    bi <- uncacheAI b st
-                    ts <- sbvToSW st t
-                    amap <- readIORef (rArrayMap st)
-                    let k = IMap.size amap
-                    k `seq` modifyIORef (rArrayMap st) (IMap.insert k ("array_" ++ show k, ainfo, ArrayMerge ts ai bi))
-                    return k
+  readArray (SArray arr) (SBV a) = SBV (readSArr arr a)
+  resetArray (SArray arr) (SBV b) = SArray (resetSArr arr b)
+  writeArray (SArray arr) (SBV a) (SBV b) = SArray (writeSArr arr a b)
+  mergeArrays (SBV t) (SArray a) (SArray b) = SArray (mergeSArr t a b)
 
 -- | Declare a new symbolic array, with a potential initial value
 declNewSArray :: forall a b. (HasKind a, HasKind b) => (Int -> String) -> Maybe (SBV b) -> Symbolic (SArray a b)
 declNewSArray mkNm mbInit = do
    let aknd = kindOf (undefined :: a)
        bknd = kindOf (undefined :: b)
-   st <- ask
-   amap <- liftIO $ readIORef $ rArrayMap st
-   let i = IMap.size amap
-       nm = mkNm i
-   actx <- liftIO $ case mbInit of
-                     Nothing   -> return $ ArrayFree Nothing
-                     Just ival -> sbvToSW st ival >>= \sw -> return $ ArrayFree (Just sw)
-   liftIO $ modifyIORef (rArrayMap st) (IMap.insert i (nm, (aknd, bknd), actx))
-   return $ SArray (aknd, bknd) $ cache $ const $ return i
+   arr <- newSArr (aknd, bknd) mkNm (fmap unSBV mbInit)
+   return (SArray arr)
 
 -- | Arrays implemented internally as functions
 --
@@ -1062,261 +480,12 @@ instance (HasKind a, HasKind b) => Show (SFunArray a b) where
 mkSFunArray :: (SBV a -> SBV b) -> SFunArray a b
 mkSFunArray = SFunArray
 
--- | Handling constraints
-imposeConstraint :: SBool -> Symbolic ()
-imposeConstraint c = do st <- ask
-                        case runMode st of
-                          CodeGen -> error "SBV: constraints are not allowed in code-generation"
-                          _       -> do liftIO $ do v <- sbvToSW st c
-                                                    modifyIORef (rConstraints st) (v:)
-
 -- | Add a constraint with a given probability
 addConstraint :: Maybe Double -> SBool -> SBool -> Symbolic ()
-addConstraint Nothing  c _  = imposeConstraint c
-addConstraint (Just t) c c'
-  | t < 0 || t > 1
-  = error $ "SBV: pConstrain: Invalid probability threshold: " ++ show t ++ ", must be in [0, 1]."
-  | True
-  = do st <- ask
-       when (not (isConcreteMode (runMode st))) $ error "SBV: pConstrain only allowed in 'genTest' or 'quickCheck' contexts."
-       case () of
-         () | t > 0 && t < 1 -> liftIO (throwDice st) >>= \d -> imposeConstraint (if d <= t then c else c')
-            | t > 0          -> imposeConstraint c
-            | True           -> imposeConstraint c'
+addConstraint mt (SBV c) (SBV c') = addSValConstraint mt c c'
 
----------------------------------------------------------------------------------
--- * Cached values
----------------------------------------------------------------------------------
-
--- | We implement a peculiar caching mechanism, applicable to the use case in
--- implementation of SBV's.  Whenever we do a state based computation, we do
--- not want to keep on evaluating it in the then-current state. That will
--- produce essentially a semantically equivalent value. Thus, we want to run
--- it only once, and reuse that result, capturing the sharing at the Haskell
--- level. This is similar to the "type-safe observable sharing" work, but also
--- takes into the account of how symbolic simulation executes.
---
--- See Andy Gill's type-safe obervable sharing trick for the inspiration behind
--- this technique: <http://ittc.ku.edu/~andygill/paper.php?label=DSLExtract09>
---
--- Note that this is *not* a general memo utility!
-newtype Cached a = Cached (State -> IO a)
-
--- | Cache a state-based computation
-cache :: (State -> IO a) -> Cached a
-cache = Cached
-
--- | Uncache a previously cached computation
-uncache :: Cached SW -> State -> IO SW
-uncache = uncacheGen rSWCache
-
--- | Uncache, retrieving array indexes
-uncacheAI :: Cached ArrayIndex -> State -> IO ArrayIndex
-uncacheAI = uncacheGen rAICache
-
--- | Generic uncaching. Note that this is entirely safe, since we do it in the IO monad.
-uncacheGen :: (State -> IORef (Cache a)) -> Cached a -> State -> IO a
-uncacheGen getCache (Cached f) st = do
-        let rCache = getCache st
-        stored <- readIORef rCache
-        sn <- f `seq` makeStableName f
-        let h = hashStableName sn
-        case maybe Nothing (sn `lookup`) (h `IMap.lookup` stored) of
-          Just r  -> return r
-          Nothing -> do r <- f st
-                        r `seq` modifyIORef rCache (IMap.insertWith (++) h [(sn, r)])
-                        return r
-
--- | Representation of SMTLib Program versions, currently we only know of versions 1 and 2.
--- (NB. Eventually, we should just drop SMTLib1.)
-data SMTLibVersion = SMTLib1
-                   | SMTLib2
-                   deriving Eq
-
--- | Representation of an SMT-Lib program. In between pre and post goes the refuted models
-data SMTLibPgm = SMTLibPgm SMTLibVersion  ( [(String, SW)]          -- alias table
-                                          , [String]                -- pre: declarations.
-                                          , [String])               -- post: formula
-instance NFData SMTLibVersion where rnf a = seq a ()
-instance NFData SMTLibPgm     where rnf a = seq a ()
-
-instance Show SMTLibPgm where
-  show (SMTLibPgm _ (_, pre, post)) = intercalate "\n" $ pre ++ post
-
--- Other Technicalities..
-instance NFData CW where
-  rnf (CW x y) = x `seq` y `seq` ()
-
-instance NFData Result where
-  rnf (Result kindInfo qcInfo cgs inps consts tbls arrs uis axs pgm cstr outs)
-        = rnf kindInfo `seq` rnf qcInfo `seq` rnf cgs  `seq` rnf inps
-                       `seq` rnf consts `seq` rnf tbls `seq` rnf arrs
-                       `seq` rnf uis    `seq` rnf axs  `seq` rnf pgm
-                       `seq` rnf cstr   `seq` rnf outs
-instance NFData Kind          where rnf a = seq a ()
-instance NFData ArrayContext  where rnf a = seq a ()
-instance NFData SW            where rnf a = seq a ()
-instance NFData SBVExpr       where rnf a = seq a ()
-instance NFData Quantifier    where rnf a = seq a ()
-instance NFData SBVType       where rnf a = seq a ()
-instance NFData UnintKind     where rnf a = seq a ()
-instance NFData a => NFData (Cached a) where
-  rnf (Cached f) = f `seq` ()
-instance NFData SVal where
-  rnf (SVal x y) = rnf x `seq` rnf y `seq` ()
 instance NFData a => NFData (SBV a) where
   rnf (SBV x) = rnf x `seq` ()
-instance NFData SBVPgm        where rnf a = seq a ()
-
-
-instance NFData SMTResult where
-  rnf (Unsatisfiable _)   = ()
-  rnf (Satisfiable _ xs)  = rnf xs `seq` ()
-  rnf (Unknown _ xs)      = rnf xs `seq` ()
-  rnf (ProofError _ xs)   = rnf xs `seq` ()
-  rnf (TimeOut _)         = ()
-
-instance NFData SMTModel where
-  rnf (SMTModel assocs unints uarrs) = rnf assocs `seq` rnf unints `seq` rnf uarrs `seq` ()
-
-instance NFData SMTScript where
-  rnf (SMTScript b m) = rnf b `seq` rnf m `seq` ()
-
--- | SMT-Lib logics. If left unspecified SBV will pick the logic based on what it determines is needed. However, the
--- user can override this choice using the 'useLogic' parameter to the configuration. This is especially handy if
--- one is experimenting with custom logics that might be supported on new solvers. See <http://smtlib.cs.uiowa.edu/logics.shtml>
--- for the official list.
-data SMTLibLogic
-  = AUFLIA    -- ^ Formulas over the theory of linear integer arithmetic and arrays extended with free sort and function symbols but restricted to arrays with integer indices and values
-  | AUFLIRA   -- ^ Linear formulas with free sort and function symbols over one- and two-dimentional arrays of integer index and real value
-  | AUFNIRA   -- ^ Formulas with free function and predicate symbols over a theory of arrays of arrays of integer index and real value
-  | LRA       -- ^ Linear formulas in linear real arithmetic
-  | QF_ABV    -- ^ Quantifier-free formulas over the theory of bitvectors and bitvector arrays
-  | QF_AUFBV  -- ^ Quantifier-free formulas over the theory of bitvectors and bitvector arrays extended with free sort and function symbols
-  | QF_AUFLIA -- ^ Quantifier-free linear formulas over the theory of integer arrays extended with free sort and function symbols
-  | QF_AX     -- ^ Quantifier-free formulas over the theory of arrays with extensionality
-  | QF_BV     -- ^ Quantifier-free formulas over the theory of fixed-size bitvectors
-  | QF_IDL    -- ^ Difference Logic over the integers. Boolean combinations of inequations of the form x - y < b where x and y are integer variables and b is an integer constant
-  | QF_LIA    -- ^ Unquantified linear integer arithmetic. In essence, Boolean combinations of inequations between linear polynomials over integer variables
-  | QF_LRA    -- ^ Unquantified linear real arithmetic. In essence, Boolean combinations of inequations between linear polynomials over real variables. 
-  | QF_NIA    -- ^ Quantifier-free integer arithmetic. 
-  | QF_NRA    -- ^ Quantifier-free real arithmetic. 
-  | QF_RDL    -- ^ Difference Logic over the reals. In essence, Boolean combinations of inequations of the form x - y < b where x and y are real variables and b is a rational constant. 
-  | QF_UF     -- ^ Unquantified formulas built over a signature of uninterpreted (i.e., free) sort and function symbols. 
-  | QF_UFBV   -- ^ Unquantified formulas over bitvectors with uninterpreted sort function and symbols. 
-  | QF_UFIDL  -- ^ Difference Logic over the integers (in essence) but with uninterpreted sort and function symbols. 
-  | QF_UFLIA  -- ^ Unquantified linear integer arithmetic with uninterpreted sort and function symbols. 
-  | QF_UFLRA  -- ^ Unquantified linear real arithmetic with uninterpreted sort and function symbols. 
-  | QF_UFNRA  -- ^ Unquantified non-linear real arithmetic with uninterpreted sort and function symbols. 
-  | UFLRA     -- ^ Linear real arithmetic with uninterpreted sort and function symbols. 
-  | UFNIA     -- ^ Non-linear integer arithmetic with uninterpreted sort and function symbols. 
-  | QF_FPBV   -- ^ Quantifier-free formulas over the theory of floating point numbers, arrays, and bit-vectors
-  | QF_FP     -- ^ Quantifier-free formulas over the theory of floating point numbers
-  deriving Show
-
--- | Chosen logic for the solver
-data Logic = PredefinedLogic SMTLibLogic  -- ^ Use one of the logics as defined by the standard
-           | CustomLogic     String       -- ^ Use this name for the logic
-
-instance Show Logic where
-  show (PredefinedLogic l) = show l
-  show (CustomLogic     s) = s
-
--- | Translation tricks needed for specific capabilities afforded by each solver
-data SolverCapabilities = SolverCapabilities {
-         capSolverName              :: String       -- ^ Name of the solver
-       , mbDefaultLogic             :: Maybe String -- ^ set-logic string to use in case not automatically determined (if any)
-       , supportsMacros             :: Bool         -- ^ Does the solver understand SMT-Lib2 macros?
-       , supportsProduceModels      :: Bool         -- ^ Does the solver understand produce-models option setting
-       , supportsQuantifiers        :: Bool         -- ^ Does the solver understand SMT-Lib2 style quantifiers?
-       , supportsUninterpretedSorts :: Bool         -- ^ Does the solver understand SMT-Lib2 style uninterpreted-sorts
-       , supportsUnboundedInts      :: Bool         -- ^ Does the solver support unbounded integers?
-       , supportsReals              :: Bool         -- ^ Does the solver support reals?
-       , supportsFloats             :: Bool         -- ^ Does the solver support single-precision floating point numbers?
-       , supportsDoubles            :: Bool         -- ^ Does the solver support double-precision floating point numbers?
-       }
-
--- | Solver configuration. See also 'z3', 'yices', 'cvc4', 'boolector', 'mathSAT', etc. which are instantiations of this type for those solvers, with
--- reasonable defaults. In particular, custom configuration can be created by varying those values. (Such as @z3{verbose=True}@.)
---
--- Most fields are self explanatory. The notion of precision for printing algebraic reals stems from the fact that such values does
--- not necessarily have finite decimal representations, and hence we have to stop printing at some depth. It is important to
--- emphasize that such values always have infinite precision internally. The issue is merely with how we print such an infinite
--- precision value on the screen. The field 'printRealPrec' controls the printing precision, by specifying the number of digits after
--- the decimal point. The default value is 16, but it can be set to any positive integer.
---
--- When printing, SBV will add the suffix @...@ at the and of a real-value, if the given bound is not sufficient to represent the real-value
--- exactly. Otherwise, the number will be written out in standard decimal notation. Note that SBV will always print the whole value if it
--- is precise (i.e., if it fits in a finite number of digits), regardless of the precision limit. The limit only applies if the representation
--- of the real value is not finite, i.e., if it is not rational.
-data SMTConfig = SMTConfig {
-         verbose        :: Bool             -- ^ Debug mode
-       , timing         :: Bool             -- ^ Print timing information on how long different phases took (construction, solving, etc.)
-       , sBranchTimeOut :: Maybe Int        -- ^ How much time to give to the solver for each call of 'sBranch' check. (In seconds. Default: No limit.)
-       , timeOut        :: Maybe Int        -- ^ How much time to give to the solver. (In seconds. Default: No limit.)
-       , printBase      :: Int              -- ^ Print integral literals in this base (2, 8, 10, and 16 are supported.)
-       , printRealPrec  :: Int              -- ^ Print algebraic real values with this precision. (SReal, default: 16)
-       , solverTweaks   :: [String]         -- ^ Additional lines of script to give to the solver (user specified)
-       , satCmd         :: String           -- ^ Usually "(check-sat)". However, users might tweak it based on solver characteristics.
-       , smtFile        :: Maybe FilePath   -- ^ If Just, the generated SMT script will be put in this file (for debugging purposes mostly)
-       , useSMTLib2     :: Bool             -- ^ If True, we'll treat the solver as using SMTLib2 input format. Otherwise, SMTLib1
-       , solver         :: SMTSolver        -- ^ The actual SMT solver.
-       , roundingMode   :: RoundingMode     -- ^ Rounding mode to use for floating-point conversions
-       , useLogic       :: Maybe Logic      -- ^ If Nothing, pick automatically. Otherwise, either use the given one, or use the custom string.
-       }
-
-instance Show SMTConfig where
-  show = show . solver
-
--- | A model, as returned by a solver
-data SMTModel = SMTModel {
-        modelAssocs    :: [(String, CW)]        -- ^ Mapping of symbolic values to constants.
-     ,  modelArrays    :: [(String, [String])]  -- ^ Arrays, very crude; only works with Yices.
-     ,  modelUninterps :: [(String, [String])]  -- ^ Uninterpreted funcs; very crude; only works with Yices.
-     }
-     deriving Show
-
--- | The result of an SMT solver call. Each constructor is tagged with
--- the 'SMTConfig' that created it so that further tools can inspect it
--- and build layers of results, if needed. For ordinary uses of the library,
--- this type should not be needed, instead use the accessor functions on
--- it. (Custom Show instances and model extractors.)
-data SMTResult = Unsatisfiable SMTConfig            -- ^ Unsatisfiable
-               | Satisfiable   SMTConfig SMTModel   -- ^ Satisfiable with model
-               | Unknown       SMTConfig SMTModel   -- ^ Prover returned unknown, with a potential (possibly bogus) model
-               | ProofError    SMTConfig [String]   -- ^ Prover errored out
-               | TimeOut       SMTConfig            -- ^ Computation timed out (see the 'timeout' combinator)
-
--- | A script, to be passed to the solver.
-data SMTScript = SMTScript {
-          scriptBody  :: String        -- ^ Initial feed
-        , scriptModel :: Maybe String  -- ^ Optional continuation script, if the result is sat
-        }
-
--- | An SMT engine
-type SMTEngine = SMTConfig -> Bool -> [(Quantifier, NamedSymVar)] -> [(String, UnintKind)] -> [Either SW (SW, [SW])] -> String -> IO SMTResult
-
--- | Solvers that SBV is aware of
-data Solver = Z3
-            | Yices
-            | Boolector
-            | CVC4
-            | MathSAT
-            | ABC
-            deriving (Show, Enum, Bounded)
-
--- | An SMT solver
-data SMTSolver = SMTSolver {
-         name           :: Solver               -- ^ The solver in use
-       , executable     :: String               -- ^ The path to its executable
-       , options        :: [String]             -- ^ Options to provide to the solver
-       , engine         :: SMTEngine            -- ^ The solver engine, responsible for interpreting solver output
-       , xformExitCode  :: ExitCode -> ExitCode -- ^ Should we re-interpret exit codes. Most solvers behave rationally, i.e., id will do. Some (like CVC4) don't.
-       , capabilities   :: SolverCapabilities   -- ^ Various capabilities of the solver
-       }
-
-instance Show SMTSolver where
-   show = show . name
 
 -- | Symbolically executable program fragments. This class is mainly used for 'safe' calls, and is sufficently populated internally to cover most use
 -- cases. Users can extend it as they wish to allow 'safe' checks for SBV programs that return/take types that are user-defined.

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -49,27 +49,14 @@ module Data.SBV.BitVectors.Data
  ) where
 
 import Control.DeepSeq      (NFData(..))
-import Control.Applicative  (Applicative)
-import Control.Monad        (when)
-import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
-import Control.Monad.Trans  (MonadIO, liftIO)
-import Data.Char            (isAlpha, isAlphaNum)
+import Control.Monad.Reader (ask)
+import Control.Monad.Trans  (liftIO)
 import Data.Int             (Int8, Int16, Int32, Int64)
 import Data.Word            (Word8, Word16, Word32, Word64)
-import Data.IORef           (IORef, newIORef, modifyIORef, readIORef, writeIORef)
-import Data.List            (intercalate, sortBy)
-import Data.Maybe           (isJust, fromJust)
+import Data.List            (intercalate)
 
-import qualified Data.Generics as G    (Data(..), DataType, dataTypeName, dataTypeOf, tyconUQname, dataTypeConstrs, constrFields)
-import qualified Data.Typeable as T    (Typeable)
-import qualified Data.IntMap   as IMap (IntMap, empty, size, toAscList, lookup, insert, insertWith)
-import qualified Data.Map      as Map  (Map, empty, toList, size, insert, lookup)
-import qualified Data.Set      as Set  (Set, empty, toList, insert)
-import qualified Data.Foldable as F    (toList)
-import qualified Data.Sequence as S    (Seq, empty, (|>))
+import qualified Data.Generics as G    (Data(..))
 
-import System.Exit           (ExitCode(..))
-import System.Mem.StableName
 import System.Random
 
 import Data.SBV.BitVectors.AlgReals

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -83,14 +83,7 @@ class HasKind a where
   isUninterpreted :: a -> Bool
   showType        :: a -> String
   -- defaults
-  hasSign x = case kindOf x of
-                  KBool        -> False
-                  KBounded b _ -> b
-                  KUnbounded   -> True
-                  KReal        -> True
-                  KFloat       -> True
-                  KDouble      -> True
-                  KUserSort{}  -> False
+  hasSign x = kindHasSign (kindOf x)
   intSizeOf x = case kindOf x of
                   KBool         -> error "SBV.HasKind.intSizeOf((S)Bool)"
                   KBounded _ s  -> s

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -31,7 +31,7 @@ module Data.SBV.BitVectors.Data
  , mkConstCW ,liftCW2, mapCW, mapCW2
  , SW(..), trueSW, falseSW, trueCW, falseCW, normCW
  , SVal(..)
- , SBV(..), NodeId(..), mkSymSBV, mkSymSBVWithRandom
+ , SBV(..), NodeId(..), mkSymSBV
  , ArrayContext(..), ArrayInfo, SymArray(..), SFunArray(..), mkSFunArray, SArray(..), arrayUIKind
  , sbvToSW, sbvToSymSW, forceSWArg
  , SBVExpr(..), newExpr
@@ -240,12 +240,9 @@ sbvToSW st (SBV s) = svToSW st s
 -- * Symbolic Computations
 -------------------------------------------------------------------------
 
--- | Create a symbolic variable. Equivalent to 'mkSymSBVWithRandom randomIO'.
-mkSymSBV :: forall a. (Random a, SymWord a) => Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
-mkSymSBV = mkSymSBVWithRandom randomIO
-
-mkSymSBVWithRandom :: forall a. SymWord a => IO (SBV a) -> Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
-mkSymSBVWithRandom rand mbQ k mbNm = fmap SBV $ mkSValWithRandom (fmap unSBV rand) mbQ k mbNm
+-- | Create a symbolic variable.
+mkSymSBV :: forall a. SymWord a => Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
+mkSymSBV mbQ k mbNm = fmap SBV (svMkSymVar mbQ k mbNm)
 
 -- | Convert a symbolic value to an SW, inside the Symbolic monad
 sbvToSymSW :: SBV a -> Symbolic SW

--- a/Data/SBV/BitVectors/Data.hs
+++ b/Data/SBV/BitVectors/Data.hs
@@ -75,116 +75,8 @@ import System.Random
 import Data.SBV.BitVectors.AlgReals
 import Data.SBV.Utils.Lib
 
--- | A constant value
-data CWVal = CWAlgReal  AlgReal              -- ^ algebraic real
-           | CWInteger  Integer              -- ^ bit-vector/unbounded integer
-           | CWFloat    Float                -- ^ float
-           | CWDouble   Double               -- ^ double
-           | CWUserSort (Maybe Int, String)  -- ^ value of an uninterpreted/user kind. The Maybe Int shows index position for enumerations
-
--- We cannot simply derive Eq/Ord for CWVal, since CWAlgReal doesn't have proper
--- instances for these when values are infinitely precise reals. However, we do
--- need a structural eq/ord for Map indexes; so define custom ones here:
-instance Eq CWVal where
-  CWAlgReal a  == CWAlgReal b       = a `algRealStructuralEqual` b
-  CWInteger a  == CWInteger b       = a == b
-  CWUserSort a == CWUserSort b = a == b
-  CWFloat a    == CWFloat b         = a == b
-  CWDouble a   == CWDouble b        = a == b
-  _            == _                 = False
-
-instance Ord CWVal where
-  CWAlgReal a `compare` CWAlgReal b   = a `algRealStructuralCompare` b
-  CWAlgReal _ `compare` CWInteger _   = LT
-  CWAlgReal _ `compare` CWFloat _     = LT
-  CWAlgReal _ `compare` CWDouble _    = LT
-  CWAlgReal _ `compare` CWUserSort _  = LT
-
-  CWInteger _ `compare` CWAlgReal _   = GT
-  CWInteger a `compare` CWInteger b   = a `compare` b
-  CWInteger _ `compare` CWFloat _     = LT
-  CWInteger _ `compare` CWDouble _    = LT
-  CWInteger _ `compare` CWUserSort _  = LT
-
-  CWFloat _   `compare` CWAlgReal _   = GT
-  CWFloat _   `compare` CWInteger _   = GT
-  CWFloat a   `compare` CWFloat b     = a `compare` b
-  CWFloat _   `compare` CWDouble _    = LT
-  CWFloat _   `compare` CWUserSort _  = LT
-
-  CWDouble _  `compare` CWAlgReal _   = GT
-  CWDouble _  `compare` CWInteger _   = GT
-  CWDouble _  `compare` CWFloat _     = GT
-  CWDouble a  `compare` CWDouble b    = a `compare` b
-  CWDouble _  `compare` CWUserSort _  = LT
-
-  CWUserSort _ `compare` CWAlgReal _  = GT
-  CWUserSort _ `compare` CWInteger _  = GT
-  CWUserSort _ `compare` CWFloat _    = GT
-  CWUserSort _ `compare` CWDouble _   = GT
-  CWUserSort a `compare` CWUserSort b = a `compare` b
-
--- | 'CW' represents a concrete word of a fixed size:
--- Endianness is mostly irrelevant (see the 'FromBits' class).
--- For signed words, the most significant digit is considered to be the sign.
-data CW = CW { cwKind   :: !Kind
-             , cwVal    :: !CWVal
-             }
-        deriving (Eq, Ord)
-
--- | Are two CW's of the same type?
-cwSameType :: CW -> CW -> Bool
-cwSameType x y = cwKind x == cwKind y
-
--- | Is this a bit?
-cwIsBit :: CW -> Bool
-cwIsBit x = case cwKind x of
-              KBool -> True
-              _     -> False
-
--- | Convert a CW to a Haskell boolean (NB. Assumes input is well-kinded)
-cwToBool :: CW -> Bool
-cwToBool x = cwVal x /= CWInteger 0
-
--- | Normalize a CW. Essentially performs modular arithmetic to make sure the
--- value can fit in the given bit-size. Note that this is rather tricky for
--- negative values, due to asymmetry. (i.e., an 8-bit negative number represents
--- values in the range -128 to 127; thus we have to be careful on the negative side.)
-normCW :: CW -> CW
-normCW c@(CW (KBounded signed sz) (CWInteger v)) = c { cwVal = CWInteger norm }
- where norm | sz == 0 = 0
-            | signed  = let rg = 2 ^ (sz - 1)
-                        in case divMod v rg of
-                                  (a, b) | even a -> b
-                                  (_, b)          -> b - rg
-            | True    = v `mod` (2 ^ sz)
-normCW c = c
-
-instance Eq  G.DataType where
-   a == b = G.tyconUQname (G.dataTypeName a) == G.tyconUQname (G.dataTypeName b)
-
-instance Ord G.DataType where
-   a `compare` b = G.tyconUQname (G.dataTypeName a) `compare` G.tyconUQname (G.dataTypeName b)
-
--- | Kind of symbolic value
-data Kind = KBool
-          | KBounded Bool Int
-          | KUnbounded
-          | KReal
-          | KUserSort String (Either String [String], G.DataType)
-          | KFloat
-          | KDouble
-          deriving (Eq, Ord)
-
-instance Show Kind where
-  show KBool              = "SBool"
-  show (KBounded False n) = "SWord" ++ show n
-  show (KBounded True n)  = "SInt"  ++ show n
-  show KUnbounded         = "SInteger"
-  show KReal              = "SReal"
-  show (KUserSort s _)    = s
-  show KFloat             = "SFloat"
-  show KDouble            = "SDouble"
+import Data.SBV.BitVectors.Kind
+import Data.SBV.BitVectors.Concrete
 
 -- | A symbolic node id
 newtype NodeId = NodeId Int deriving (Eq, Ord)
@@ -213,14 +105,6 @@ falseSW = SW KBool $ NodeId (-2)
 -- | Constant False as a SW. Note that this value always occupies slot -1.
 trueSW :: SW
 trueSW  = SW KBool $ NodeId (-1)
-
--- | Constant False as a CW. We represent it using the integer value 0.
-falseCW :: CW
-falseCW = CW KBool (CWInteger 0)
-
--- | Constant True as a CW. We represent it using the integer value 1.
-trueCW :: CW
-trueCW  = CW KBool (CWInteger 1)
 
 -- | A simple type for SBV computations, used mainly for uninterpreted constants.
 -- We keep track of the signedness/size of the arguments. A non-function will
@@ -338,52 +222,11 @@ instance HasKind AlgReal where kindOf _ = KReal
 instance HasKind Float   where kindOf _ = KFloat
 instance HasKind Double  where kindOf _ = KDouble
 
--- | Lift a unary function thruough a CW
-liftCW :: (AlgReal -> b) -> (Integer -> b) -> (Float -> b) -> (Double -> b) -> ((Maybe Int, String) -> b) -> CW -> b
-liftCW f _ _ _ _ (CW _ (CWAlgReal v))  = f v
-liftCW _ f _ _ _ (CW _ (CWInteger v))  = f v
-liftCW _ _ f _ _ (CW _ (CWFloat v))    = f v
-liftCW _ _ _ f _ (CW _ (CWDouble v))   = f v
-liftCW _ _ _ _ f (CW _ (CWUserSort v)) = f v
-
--- | Lift a binary function through a CW
-liftCW2 :: (AlgReal -> AlgReal -> b) -> (Integer -> Integer -> b) -> (Float -> Float -> b) -> (Double -> Double -> b) -> ((Maybe Int, String) -> (Maybe Int, String) -> b) -> CW -> CW -> b
-liftCW2 r i f d u x y = case (cwVal x, cwVal y) of
-                         (CWAlgReal a,  CWAlgReal b)  -> r a b
-                         (CWInteger a,  CWInteger b)  -> i a b
-                         (CWFloat a,    CWFloat b)    -> f a b
-                         (CWDouble a,   CWDouble b)   -> d a b
-                         (CWUserSort a, CWUserSort b) -> u a b
-                         _                            -> error $ "SBV.liftCW2: impossible, incompatible args received: " ++ show (x, y)
-
--- | Map a unary function through a CW
-mapCW :: (AlgReal -> AlgReal) -> (Integer -> Integer) -> (Float -> Float) -> (Double -> Double) -> ((Maybe Int, String) -> (Maybe Int, String)) -> CW -> CW
-mapCW r i f d u x  = normCW $ CW (cwKind x) $ case cwVal x of
-                                               CWAlgReal a  -> CWAlgReal  (r a)
-                                               CWInteger a  -> CWInteger  (i a)
-                                               CWFloat a    -> CWFloat    (f a)
-                                               CWDouble a   -> CWDouble   (d a)
-                                               CWUserSort a -> CWUserSort (u a)
-
--- | Map a binary function through a CW
-mapCW2 :: (AlgReal -> AlgReal -> AlgReal) -> (Integer -> Integer -> Integer) -> (Float -> Float -> Float) -> (Double -> Double -> Double) -> ((Maybe Int, String) -> (Maybe Int, String) -> (Maybe Int, String)) -> CW -> CW -> CW
-mapCW2 r i f d u x y = case (cwSameType x y, cwVal x, cwVal y) of
-                        (True, CWAlgReal a,  CWAlgReal b)  -> normCW $ CW (cwKind x) (CWAlgReal  (r a b))
-                        (True, CWInteger a,  CWInteger b)  -> normCW $ CW (cwKind x) (CWInteger  (i a b))
-                        (True, CWFloat a,    CWFloat b)    -> normCW $ CW (cwKind x) (CWFloat    (f a b))
-                        (True, CWDouble a,   CWDouble b)   -> normCW $ CW (cwKind x) (CWDouble   (d a b))
-                        (True, CWUserSort a, CWUserSort b) -> normCW $ CW (cwKind x) (CWUserSort (u a b))
-                        _                                  -> error $ "SBV.mapCW2: impossible, incompatible args received: " ++ show (x, y)
-
 instance HasKind CW where
   kindOf = cwKind
 
 instance HasKind SW where
   kindOf (SW k _) = k
-
-instance Show CW where
-  show w | cwIsBit w = show (cwToBool w)
-  show w             = liftCW show show show show snd w ++ " :: " ++ showType w
 
 instance Show SW where
   show (SW _ (NodeId n))
@@ -807,16 +650,6 @@ getTableIndex st at rt elts = do
                           modifyIORef (rtblMap st) (Map.insert elts (i, at, rt))
                           return i
 
--- | Create a constant word from an integral
-mkConstCW :: Integral a => Kind -> a -> CW
-mkConstCW KBool           a = normCW $ CW KBool      (CWInteger (toInteger a))
-mkConstCW k@(KBounded{})  a = normCW $ CW k          (CWInteger (toInteger a))
-mkConstCW KUnbounded      a = normCW $ CW KUnbounded (CWInteger (toInteger a))
-mkConstCW KReal           a = normCW $ CW KReal      (CWAlgReal (fromInteger (toInteger a)))
-mkConstCW KFloat          a = normCW $ CW KFloat     (CWFloat   (fromInteger (toInteger a)))
-mkConstCW KDouble         a = normCW $ CW KDouble    (CWDouble  (fromInteger (toInteger a)))
-mkConstCW (KUserSort s _) a = error $ "Unexpected call to mkConstCW with uninterpreted kind: " ++ s ++ " with value: " ++ show (toInteger a)
-
 -- | Create a new expression; hash-cons as necessary
 newExpr :: State -> Kind -> SBVExpr -> IO SW
 newExpr st k app = do
@@ -1006,25 +839,6 @@ extractSymbolicSimulationState st@State{ spgm=pgm, rinps=inps, routs=outs, rtblM
    traceVals <- reverse `fmap` readIORef cInfo
    extraCstrs <- reverse `fmap` readIORef cstrs
    return $ Result knds traceVals cgMap inpsO cnsts tbls arrs unint axs (SBVPgm rpgm) extraCstrs outsO
-
--- | Construct an uninterpreted/enumerated kind from a piece of data; we distinguish simple enumerations as those
--- are mapped to proper SMT-Lib2 data-types; while others go completely uninterpreted
-constructUKind :: forall a. (Read a, G.Data a) => a -> Kind
-constructUKind a = KUserSort sortName (mbEnumFields, dataType)
-  where dataType      = G.dataTypeOf a
-        sortName      = G.tyconUQname . G.dataTypeName $ dataType
-        constrs       = G.dataTypeConstrs dataType
-        isEnumeration = not (null constrs) && all (null . G.constrFields) constrs
-        mbEnumFields
-         | isEnumeration = check constrs []
-         | True          = Left $ sortName ++ "is not a finite non-empty enumeration"
-        check []     sofar = Right $ reverse sofar
-        check (c:cs) sofar = case checkConstr c of
-                                Nothing -> check cs (show c : sofar)
-                                Just s  -> Left $ sortName ++ "." ++ show c ++ ": " ++ s
-        checkConstr c = case (reads (show c) :: [(a, String)]) of
-                          ((_, "") : _)  -> Nothing
-                          _              -> Just $ "not a nullary constructor"
 
 -------------------------------------------------------------------------------
 -- * Symbolic Words

--- a/Data/SBV/BitVectors/Kind.hs
+++ b/Data/SBV/BitVectors/Kind.hs
@@ -1,0 +1,66 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.BitVectors.Kind
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Internal data-structures for the sbv library
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE    ScopedTypeVariables        #-}
+
+module Data.SBV.BitVectors.Kind
+  ( Kind(..)
+  , constructUKind
+  ) where
+
+import qualified Data.Generics as G (Data(..), DataType, dataTypeName, dataTypeOf, tyconUQname, dataTypeConstrs, constrFields)
+
+import Data.SBV.BitVectors.AlgReals
+
+-- | Kind of symbolic value
+data Kind = KBool
+          | KBounded Bool Int
+          | KUnbounded
+          | KReal
+          | KUserSort String (Either String [String], G.DataType)
+          | KFloat
+          | KDouble
+          deriving (Eq, Ord)
+
+instance Show Kind where
+  show KBool              = "SBool"
+  show (KBounded False n) = "SWord" ++ show n
+  show (KBounded True n)  = "SInt"  ++ show n
+  show KUnbounded         = "SInteger"
+  show KReal              = "SReal"
+  show (KUserSort s _)    = s
+  show KFloat             = "SFloat"
+  show KDouble            = "SDouble"
+
+instance Eq  G.DataType where
+   a == b = G.tyconUQname (G.dataTypeName a) == G.tyconUQname (G.dataTypeName b)
+
+instance Ord G.DataType where
+   a `compare` b = G.tyconUQname (G.dataTypeName a) `compare` G.tyconUQname (G.dataTypeName b)
+
+-- | Construct an uninterpreted/enumerated kind from a piece of data; we distinguish simple enumerations as those
+-- are mapped to proper SMT-Lib2 data-types; while others go completely uninterpreted
+constructUKind :: forall a. (Read a, G.Data a) => a -> Kind
+constructUKind a = KUserSort sortName (mbEnumFields, dataType)
+  where dataType      = G.dataTypeOf a
+        sortName      = G.tyconUQname . G.dataTypeName $ dataType
+        constrs       = G.dataTypeConstrs dataType
+        isEnumeration = not (null constrs) && all (null . G.constrFields) constrs
+        mbEnumFields
+         | isEnumeration = check constrs []
+         | True          = Left $ sortName ++ "is not a finite non-empty enumeration"
+        check []     sofar = Right $ reverse sofar
+        check (c:cs) sofar = case checkConstr c of
+                                Nothing -> check cs (show c : sofar)
+                                Just s  -> Left $ sortName ++ "." ++ show c ++ ": " ++ s
+        checkConstr c = case (reads (show c) :: [(a, String)]) of
+                          ((_, "") : _)  -> Nothing
+                          _              -> Just $ "not a nullary constructor"

--- a/Data/SBV/BitVectors/Kind.hs
+++ b/Data/SBV/BitVectors/Kind.hs
@@ -13,6 +13,7 @@
 
 module Data.SBV.BitVectors.Kind
   ( Kind(..)
+  , kindHasSign
   , constructUKind
   ) where
 
@@ -45,6 +46,17 @@ instance Eq  G.DataType where
 
 instance Ord G.DataType where
    a `compare` b = G.tyconUQname (G.dataTypeName a) `compare` G.tyconUQname (G.dataTypeName b)
+
+kindHasSign :: Kind -> Bool
+kindHasSign k =
+  case k of
+    KBool        -> False
+    KBounded b _ -> b
+    KUnbounded   -> True
+    KReal        -> True
+    KFloat       -> True
+    KDouble      -> True
+    KUserSort{}  -> False
 
 -- | Construct an uninterpreted/enumerated kind from a piece of data; we distinguish simple enumerations as those
 -- are mapped to proper SMT-Lib2 data-types; while others go completely uninterpreted

--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -60,6 +60,8 @@ import Data.SBV.Utils.Boolean
 import Data.SBV.Provers.Prover (isSBranchFeasibleInState, isConditionSatisfiable, isVacuous, prove, defaultSMTCfg)
 import Data.SBV.SMT.SMT (SafeResult(..), SatResult(..), ThmResult, getModelDictionary)
 
+import Data.SBV.BitVectors.Symbolic
+
 -- | Newer versions of GHC (Starting with 7.8 I think), distinguishes between FiniteBits and Bits classes.
 -- We should really use FiniteBitSize for SBV which would make things better. In the interim, just work
 -- around pesky warnings..
@@ -1529,10 +1531,7 @@ instance (SymWord a, Bounded a) => Bounded (SBV a) where
 
 -- SArrays are both "EqSymbolic" and "Mergeable"
 instance EqSymbolic (SArray a b) where
-  (SArray _ a) .== (SArray _ b) = SBV $ SVal KBool $ Right $ cache c
-    where c st = do ai <- uncacheAI a st
-                    bi <- uncacheAI b st
-                    newExpr st KBool (SBVApp (ArrEq ai bi) [])
+  (SArray a) .== (SArray b) = SBV (eqSArr a b)
 
 -- When merging arrays; we'll ignore the force argument. This is arguably
 -- the right thing to do as we've too many things and likely we want to keep it efficient.

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -193,10 +193,10 @@ svXOr x y
   | True             = liftSym2 (mkSymOpSC opt XOr) (const (const True))
                        (noReal "xor") xor (noFloat "xor") (noDouble "xor") x y
   where opt a b
-          | a == b       = Just falseSW
-          | a == falseSW = Just b
-          | b == falseSW = Just a
-          | True         = Nothing
+          | a == b && swKind a == KBool = Just falseSW
+          | a == falseSW                = Just b
+          | b == falseSW                = Just a
+          | True                        = Nothing
 
 svNot :: SVal -> SVal
 svNot = liftSym1 (mkSymOp1SC opt Not)

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -187,7 +187,9 @@ svOr x y
 svXOr :: SVal -> SVal -> SVal
 svXOr x y
   | isConcreteZero x = y
+  | isConcreteOnes x = svNot y
   | isConcreteZero y = x
+  | isConcreteOnes y = svNot x
   | True             = liftSym2 (mkSymOpSC opt XOr) (const (const True))
                        (noReal "xor") xor (noFloat "xor") (noDouble "xor") x y
   where opt a b

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -92,7 +92,7 @@ svQuot x y
   | True             = liftSym2 (mkSymOp Quot) nonzeroCheck
                        (noReal "quot") quot' (noFloat "quot") (noDouble "quot") x y
   where
-    quot' a b | svKind x == KUnbounded = div a (abs b)
+    quot' a b | svKind x == KUnbounded = div a (abs b) * signum b
               | otherwise              = quot a b
 
 -- | Overloaded operation whose meaning depends on the kind at which

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -22,6 +22,7 @@ module Data.SBV.BitVectors.Operations
   , svShl, svShr, svRol, svRor
   , svExtract, svJoin
   , svUninterpreted
+  , svSymbolicMerge
   )
   where
 
@@ -244,6 +245,88 @@ svUninterpreted k nm code args = SVal k $ Right $ cache result
                        mapM_ forceSWArg sws
                        newExpr st k $ SBVApp (Uninterpreted nm) sws
 
+svAsBool :: SVal -> Maybe Bool
+svAsBool (SVal _ (Left cw)) = Just (cwToBool cw)
+svAsBool _                  = Nothing
+
+-- | Merge two symbolic values, at kind @k@, possibly @force@'ing the branches to make
+-- sure they do not evaluate to the same result.
+svSymbolicMerge :: Kind -> Bool -> SVal -> SVal -> SVal -> SVal
+svSymbolicMerge k force t a b
+  | Just r <- svAsBool t
+  = if r then a else b
+  | force, rationalSBVCheck a b, areConcretelyEqual a b
+  = a
+  | True
+  = SVal k $ Right $ cache c
+  where c st = do swt <- svToSW st t
+                  case () of
+                    () | swt == trueSW  -> svToSW st a       -- these two cases should never be needed as we expect symbolicMerge to be
+                    () | swt == falseSW -> svToSW st b       -- called with symbolic tests, but just in case..
+                    () -> do {- It is tempting to record the choice of the test expression here as we branch down to the 'then' and 'else' branches. That is,
+                                when we evaluate 'a', we can make use of the fact that the test expression is True, and similarly we can use the fact that it
+                                is False when b is evaluated. In certain cases this can cut down on symbolic simulation significantly, for instance if
+                                repetitive decisions are made in a recursive loop. Unfortunately, the implementation of this idea is quite tricky, due to
+                                our sharing based implementation. As the 'then' branch is evaluated, we will create many expressions that are likely going
+                                to be "reused" when the 'else' branch is executed. But, it would be *dead wrong* to share those values, as they were "cached"
+                                under the incorrect assumptions. To wit, consider the following:
+
+                                   foo x y = ite (y .== 0) k (k+1)
+                                     where k = ite (y .== 0) x (x+1)
+
+                                When we reduce the 'then' branch of the first ite, we'd record the assumption that y is 0. But while reducing the 'then' branch, we'd
+                                like to share 'k', which would evaluate (correctly) to 'x' under the given assumption. When we backtrack and evaluate the 'else'
+                                branch of the first ite, we'd see 'k' is needed again, and we'd look it up from our sharing map to find (incorrectly) that its value
+                                is 'x', which was stored there under the assumption that y was 0, which no longer holds. Clearly, this is unsound.
+
+                                A sound implementation would have to precisely track which assumptions were active at the time expressions get shared. That is,
+                                in the above example, we should record that the value of 'k' was cached under the assumption that 'y' is 0. While sound, this
+                                approach unfortunately leads to significant loss of valid sharing when the value itself had nothing to do with the assumption itself.
+                                To wit, consider:
+
+                                   foo x y = ite (y .== 0) k (k+1)
+                                     where k = x+5
+
+                                If we tracked the assumptions, we would recompute 'k' twice, since the branch assumptions would differ. Clearly, there is no need to
+                                re-compute 'k' in this case since its value is independent of y. Note that the whole SBV performance story is based on agressive sharing,
+                                and losing that would have other significant ramifications.
+
+                                The "proper" solution would be to track, with each shared computation, precisely which assumptions it actually *depends* on, rather
+                                than blindly recording all the assumptions present at that time. SBV's symbolic simulation engine clearly has all the info needed to do this
+                                properly, but the implementation is not straightforward at all. For each subexpression, we would need to chase down its dependencies
+                                transitively, which can require a lot of scanning of the generated program causing major slow-down; thus potentially defeating the
+                                whole purpose of sharing in the first place.
+
+                                Design choice: Keep it simple, and simply do not track the assumption at all. This will maximize sharing, at the cost of evaluating
+                                unreachable branches. I think the simplicity is more important at this point than efficiency.
+
+                                Also note that the user can avoid most such issues by properly combining if-then-else's with common conditions together. That is, the
+                                first program above should be written like this:
+
+                                  foo x y = ite (y .== 0) x (x+2)
+
+                                In general, the following transformations should be done whenever possible:
+
+                                  ite e1 (ite e1 e2 e3) e4  --> ite e1 e2 e4
+                                  ite e1 e2 (ite e1 e3 e4)  --> ite e1 e2 e4
+
+                                This is in accordance with the general rule-of-thumb stating conditionals should be avoided as much as possible. However, we might prefer
+                                the following:
+
+                                  ite e1 (f e2 e4) (f e3 e5) --> f (ite e1 e2 e3) (ite e1 e4 e5)
+
+                                especially if this expression happens to be inside 'f's body itself (i.e., when f is recursive), since it reduces the number of
+                                recursive calls. Clearly, programming with symbolic simulation in mind is another kind of beast alltogether.
+                             -}
+                             let sta = st `extendSValPathCondition` (svAnd t)
+                             let stb = st `extendSValPathCondition` (svAnd (svNot t))
+                             swa <- svToSW sta a -- evaluate 'then' branch
+                             swb <- svToSW stb b -- evaluate 'else' branch
+                             case () of               -- merge:
+                               () | swa == swb                      -> return swa
+                               () | swa == trueSW && swb == falseSW -> return swt
+                               () | swa == falseSW && swb == trueSW -> newExpr st k (SBVApp Not [swt])
+                               ()                                   -> newExpr st k (SBVApp Ite [swt, swa, swb])
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -17,7 +17,7 @@ module Data.SBV.BitVectors.Operations
   , svAsBool
   -- ** Basic operations
   , svPlus, svTimes, svMinus, svUNeg, svAbs
-  , svQuot, svRem
+  , svDivide, svQuot, svRem
   , svEqual, svNotEqual
   , svLessThan, svGreaterThan, svLessEq, svGreaterEq
   , svAnd, svOr, svXOr, svNot
@@ -89,6 +89,11 @@ svUNeg = liftSym1 (mkSymOp1 UNeg) negate negate negate negate
 
 svAbs :: SVal -> SVal
 svAbs = liftSym1 (mkSymOp1 Abs) abs abs abs abs
+
+svDivide :: SVal -> SVal -> SVal
+svDivide = liftSym2 (mkSymOp Quot) rationalCheck (/) die (/) (/)
+   where -- should never happen
+         die = error "impossible: integer valued data found in Fractional instance"
 
 -- | Overloaded operation whose meaning depends on the kind at which
 -- it is used: For unbounded integers, it corresponds to the SMT-Lib

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -1,0 +1,370 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.BitVectors.Operations
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Constructors and basic operations on symbolic values
+-----------------------------------------------------------------------------
+
+module Data.SBV.BitVectors.Operations
+  (
+  -- ** Basic constructors
+    svTrue, svFalse, svBool
+  , svInteger
+  -- ** Basic operations
+  , svPlus, svTimes, svMinus, svUNeg, svAbs
+  , svEqual, svNotEqual
+  , svLessThan, svGreaterThan, svLessEq, svGreaterEq
+  , svAnd, svOr, svXOr, svNot
+  , svShl, svShr, svRol, svRor
+  , svExtract, svJoin
+  , svUninterpreted
+  )
+  where
+
+import Data.Bits (Bits(..))
+
+import Data.SBV.BitVectors.AlgReals
+import Data.SBV.BitVectors.Kind
+import Data.SBV.BitVectors.Concrete
+import Data.SBV.BitVectors.Symbolic
+
+--------------------------------------------------------------------------------
+-- Basic constructors
+
+svTrue :: SVal
+svTrue = SVal KBool (Left trueCW)
+
+svFalse :: SVal
+svFalse = SVal KBool (Left falseCW)
+
+svBool :: Bool -> SVal
+svBool b = if b then svTrue else svFalse
+
+svInteger :: Kind -> Integer -> SVal
+svInteger k n = SVal k (Left (mkConstCW k n))
+
+--TODO: svFloat, svDouble, svReal
+
+--------------------------------------------------------------------------------
+-- Basic operations
+
+svPlus :: SVal -> SVal -> SVal
+svPlus x y
+  | isConcreteZero x = y
+  | isConcreteZero y = x
+  | True             = liftSym2 (mkSymOp Plus) rationalCheck (+) (+) (+) (+) x y
+
+svTimes :: SVal -> SVal -> SVal
+svTimes x y
+  | isConcreteZero x = x
+  | isConcreteZero y = y
+  | isConcreteOne x  = y
+  | isConcreteOne y  = x
+  | True             = liftSym2 (mkSymOp Times) rationalCheck (*) (*) (*) (*) x y
+
+svMinus :: SVal -> SVal -> SVal
+svMinus x y
+  | isConcreteZero y = x
+  | True             = liftSym2 (mkSymOp Minus) rationalCheck (-) (-) (-) (-) x y
+
+svUNeg :: SVal -> SVal
+svUNeg = liftSym1 (mkSymOp1 UNeg) negate negate negate negate
+
+svAbs :: SVal -> SVal
+svAbs = liftSym1 (mkSymOp1 Abs) abs abs abs abs
+
+svEqual :: SVal -> SVal -> SVal
+svEqual = liftSym2B (mkSymOpSC (eqOpt trueSW) Equal) rationalCheck (==) (==) (==) (==) (==)
+
+svNotEqual :: SVal -> SVal -> SVal
+svNotEqual = liftSym2B (mkSymOpSC (eqOpt falseSW) NotEqual) rationalCheck (/=) (/=) (/=) (/=) (/=)
+
+svLessThan :: SVal -> SVal -> SVal
+svLessThan x y
+  | isConcreteMax x = svFalse
+  | isConcreteMin y = svFalse
+  | True            = liftSym2B (mkSymOpSC (eqOpt falseSW) LessThan) rationalCheck (<) (<) (<) (<) (uiLift "<" (<)) x y
+
+svGreaterThan :: SVal -> SVal -> SVal
+svGreaterThan x y
+  | isConcreteMin x = svFalse
+  | isConcreteMax y = svFalse
+  | True            = liftSym2B (mkSymOpSC (eqOpt falseSW) GreaterThan) rationalCheck (>) (>) (>) (>) (uiLift ">"  (>)) x y
+
+svLessEq :: SVal -> SVal -> SVal
+svLessEq x y
+  | isConcreteMin x = svTrue
+  | isConcreteMax y = svTrue
+  | True            = liftSym2B (mkSymOpSC (eqOpt trueSW) LessEq) rationalCheck (<=) (<=) (<=) (<=) (uiLift "<=" (<=)) x y
+
+svGreaterEq :: SVal -> SVal -> SVal
+svGreaterEq x y
+  | isConcreteMax x = svTrue
+  | isConcreteMin y = svTrue
+  | True            = liftSym2B (mkSymOpSC (eqOpt trueSW) GreaterEq) rationalCheck (>=) (>=) (>=) (>=) (uiLift ">=" (>=)) x y
+
+svAnd :: SVal -> SVal -> SVal
+svAnd x y
+  | isConcreteZero x = x
+  | isConcreteOnes x = y
+  | isConcreteZero y = y
+  | isConcreteOnes y = x
+  | True             = liftSym2 (mkSymOpSC opt And) (const (const True)) (noReal ".&.") (.&.) (noFloat ".&.") (noDouble ".&.") x y
+  where opt a b
+          | a == falseSW || b == falseSW = Just falseSW
+          | a == trueSW                  = Just b
+          | b == trueSW                  = Just a
+          | True                         = Nothing
+
+svOr :: SVal -> SVal -> SVal
+svOr x y
+  | isConcreteZero x = y
+  | isConcreteOnes x = x
+  | isConcreteZero y = x
+  | isConcreteOnes y = y
+  | True             = liftSym2 (mkSymOpSC opt Or) (const (const True))
+                       (noReal ".|.") (.|.) (noFloat ".|.") (noDouble ".|.") x y
+  where opt a b
+          | a == trueSW || b == trueSW = Just trueSW
+          | a == falseSW               = Just b
+          | b == falseSW               = Just a
+          | True                       = Nothing
+
+svXOr :: SVal -> SVal -> SVal
+svXOr x y
+  | isConcreteZero x = y
+  | isConcreteZero y = x
+  | True             = liftSym2 (mkSymOpSC opt XOr) (const (const True))
+                       (noReal "xor") xor (noFloat "xor") (noDouble "xor") x y
+  where opt a b
+          | a == b       = Just falseSW
+          | a == falseSW = Just b
+          | b == falseSW = Just a
+          | True         = Nothing
+
+svNot :: SVal -> SVal
+svNot = liftSym1 (mkSymOp1SC opt Not)
+        (noRealUnary "complement") complement
+        (noFloatUnary "complement") (noDoubleUnary "complement")
+  where opt a
+          | a == falseSW = Just trueSW
+          | a == trueSW  = Just falseSW
+          | True         = Nothing
+
+svShl :: SVal -> Int -> SVal
+svShl x i
+  | i < 0   = svShr x (-i)
+  | i == 0  = x
+  | True    = liftSym1 (mkSymOp1 (Shl i))
+              (noRealUnary "shiftL") (`shiftL` i)
+              (noFloatUnary "shiftL") (noDoubleUnary "shiftL") x
+
+svShr :: SVal -> Int -> SVal
+svShr x i
+  | i < 0   = svShl x (-i)
+  | i == 0  = x
+  | True    = liftSym1 (mkSymOp1 (Shr i))
+              (noRealUnary "shiftR") (`shiftR` i)
+              (noFloatUnary "shiftR") (noDoubleUnary "shiftR") x
+
+svRol :: SVal -> Int -> SVal
+svRol x i
+  | i < 0   = svRor x (-i)
+  | i == 0  = x
+  | True    = case svKind x of
+                KBounded _ sz -> liftSym1 (mkSymOp1 (Rol (i `mod` sz)))
+                                 (noRealUnary "rotateL") (rot True sz i)
+                                 (noFloatUnary "rotateL") (noDoubleUnary "rotateL") x
+                _ -> svShl x i   -- for unbounded Integers, rotateL is the same as shiftL in Haskell
+
+svRor :: SVal -> Int -> SVal
+svRor x i
+  | i < 0   = svRol x (-i)
+  | i == 0  = x
+  | True    = case svKind x of
+                KBounded _ sz -> liftSym1 (mkSymOp1 (Ror (i `mod` sz)))
+                                 (noRealUnary "rotateR") (rot False sz i)
+                                 (noFloatUnary "rotateR") (noDoubleUnary "rotateR") x
+                _ -> svShr x i   -- for unbounded integers, rotateR is the same as shiftR in Haskell
+
+-- Since the underlying representation is just Integers, rotations has to be careful on the bit-size
+rot :: Bool -> Int -> Int -> Integer -> Integer
+rot toLeft sz amt x
+  | sz < 2 = x
+  | True   = norm x y' `shiftL` y  .|. norm (x `shiftR` y') y
+  where (y, y') | toLeft = (amt `mod` sz, sz - y)
+                | True   = (sz - y', amt `mod` sz)
+        norm v s = v .&. ((1 `shiftL` s) - 1)
+
+svExtract :: Int -> Int -> SVal -> SVal
+svExtract i j x@(SVal (KBounded s _) _)
+  | i < j
+  = SVal k (Left (CW k (CWInteger 0)))
+  | SVal _ (Left (CW _ (CWInteger v))) <- x
+  = SVal k (Left (normCW (CW k (CWInteger (v `shiftR` j)))))
+  | True
+  = SVal k (Right (cache y))
+  where k = KBounded s (i - j + 1)
+        y st = do sw <- svToSW st x
+                  newExpr st k (SBVApp (Extract i j) [sw])
+svExtract _ _ _ = error "extract: non-bitvector type"
+
+svJoin :: SVal -> SVal -> SVal
+svJoin x@(SVal (KBounded s i) a) y@(SVal (KBounded _ j) b)
+  | i == 0 = y
+  | j == 0 = x
+  | Left (CW _ (CWInteger m)) <- a, Left (CW _ (CWInteger n)) <- b
+  = SVal k (Left (CW k (CWInteger ((m `shiftL` j .|. n)))))
+  | True
+  = SVal k (Right (cache z))
+  where
+    k = KBounded s (i + j)
+    z st = do xsw <- svToSW st x
+              ysw <- svToSW st y
+              newExpr st k (SBVApp Join [xsw, ysw])
+svJoin _ _ = error "svJoin: non-bitvector type"
+
+-- | Uninterpreted constants and functions. An uninterpreted constant is
+-- a value that is indexed by its name. The only property the prover assumes
+-- about these values are that they are equivalent to themselves; i.e., (for
+-- functions) they return the same results when applied to same arguments.
+-- We support uninterpreted-functions as a general means of black-box'ing
+-- operations that are /irrelevant/ for the purposes of the proof; i.e., when
+-- the proofs can be performed without any knowledge about the function itself.
+
+svUninterpreted :: Kind -> String -> Maybe [String] -> [SVal] -> SVal
+svUninterpreted k nm code args = SVal k $ Right $ cache result
+  where result st = do let ty = SBVType (map svKind args ++ [k])
+                       newUninterpreted st nm ty code
+                       sws <- mapM (svToSW st) args
+                       mapM_ forceSWArg sws
+                       newExpr st k $ SBVApp (Uninterpreted nm) sws
+
+
+--------------------------------------------------------------------------------
+-- Utility functions
+
+noUnint  :: (Maybe Int, String) -> a
+noUnint x = error $ "Unexpected operation called on uninterpreted/enumerated value: " ++ show x
+
+noUnint2 :: (Maybe Int, String) -> (Maybe Int, String) -> a
+noUnint2 x y = error $ "Unexpected binary operation called on uninterpreted/enumerated values: " ++ show (x, y)
+
+liftSym1 :: (State -> Kind -> SW -> IO SW) -> (AlgReal -> AlgReal) -> (Integer -> Integer) -> (Float -> Float) -> (Double -> Double) -> SVal -> SVal
+liftSym1 _   opCR opCI opCF opCD   (SVal k (Left a)) = SVal k $ Left  $ mapCW opCR opCI opCF opCD noUnint a
+liftSym1 opS _    _    _    _    a@(SVal k _)        = SVal k $ Right $ cache c
+   where c st = do swa <- svToSW st a
+                   opS st k swa
+
+liftSW2 :: (State -> Kind -> SW -> SW -> IO SW) -> Kind -> SVal -> SVal -> Cached SW
+liftSW2 opS k a b = cache c
+  where c st = do sw1 <- svToSW st a
+                  sw2 <- svToSW st b
+                  opS st k sw1 sw2
+
+liftSym2 :: (State -> Kind -> SW -> SW -> IO SW) -> (CW -> CW -> Bool) -> (AlgReal -> AlgReal -> AlgReal) -> (Integer -> Integer -> Integer) -> (Float -> Float -> Float) -> (Double -> Double -> Double) -> SVal -> SVal -> SVal
+liftSym2 _   okCW opCR opCI opCF opCD   (SVal k (Left a)) (SVal _ (Left b)) | okCW a b = SVal k $ Left  $ mapCW2 opCR opCI opCF opCD noUnint2 a b
+liftSym2 opS _    _    _    _    _    a@(SVal k _)        b                            = SVal k $ Right $ liftSW2 opS k a b
+
+liftSym2B :: (State -> Kind -> SW -> SW -> IO SW) -> (CW -> CW -> Bool) -> (AlgReal -> AlgReal -> Bool) -> (Integer -> Integer -> Bool) -> (Float -> Float -> Bool) -> (Double -> Double -> Bool) -> ((Maybe Int, String) -> (Maybe Int, String) -> Bool) -> SVal -> SVal -> SVal
+liftSym2B _   okCW opCR opCI opCF opCD opUI (SVal _ (Left a)) (SVal _ (Left b)) | okCW a b = svBool (liftCW2 opCR opCI opCF opCD opUI a b)
+liftSym2B opS _    _    _    _    _    _    a                 b                            = SVal KBool $ Right $ liftSW2 opS KBool a b
+
+mkSymOpSC :: (SW -> SW -> Maybe SW) -> Op -> State -> Kind -> SW -> SW -> IO SW
+mkSymOpSC shortCut op st k a b = maybe (newExpr st k (SBVApp op [a, b])) return (shortCut a b)
+
+mkSymOp :: Op -> State -> Kind -> SW -> SW -> IO SW
+mkSymOp = mkSymOpSC (const (const Nothing))
+
+mkSymOp1SC :: (SW -> Maybe SW) -> Op -> State -> Kind -> SW -> IO SW
+mkSymOp1SC shortCut op st k a = maybe (newExpr st k (SBVApp op [a])) return (shortCut a)
+
+mkSymOp1 :: Op -> State -> Kind -> SW -> IO SW
+mkSymOp1 = mkSymOp1SC (const Nothing)
+
+-- | eqOpt says the references are to the same SW, thus we can optimize. Note that
+-- we explicitly disallow KFloat/KDouble here. Why? Because it's *NOT* true that
+-- NaN == NaN, NaN >= NaN, and so-forth. So, we have to make sure we don't optimize
+-- floats and doubles, in case the argument turns out to be NaN.
+eqOpt :: SW -> SW -> SW -> Maybe SW
+eqOpt w x y = case swKind x of
+                KFloat  -> Nothing
+                KDouble -> Nothing
+                _       -> if x == y then Just w else Nothing
+
+-- For uninterpreted/enumerated values, we carefully lift through the constructor index for comparisons:
+uiLift :: String -> (Int -> Int -> Bool) -> (Maybe Int, String) -> (Maybe Int, String) -> Bool
+uiLift _ cmp (Just i, _) (Just j, _) = i `cmp` j
+uiLift w _   a           b           = error $ "Data.SBV.BitVectors.Model: Impossible happened while trying to lift " ++ w ++ " over " ++ show (a, b)
+
+-- | Predicate for optimizing word operations like (+) and (*).
+isConcreteZero :: SVal -> Bool
+isConcreteZero (SVal _     (Left (CW _     (CWInteger n)))) = n == 0
+isConcreteZero (SVal KReal (Left (CW KReal (CWAlgReal v)))) = isExactRational v && v == 0
+isConcreteZero _                                            = False
+
+-- | Predicate for optimizing word operations like (+) and (*).
+isConcreteOne :: SVal -> Bool
+isConcreteOne (SVal _     (Left (CW _     (CWInteger 1)))) = True
+isConcreteOne (SVal KReal (Left (CW KReal (CWAlgReal v)))) = isExactRational v && v == 1
+isConcreteOne _                                            = False
+
+-- | Predicate for optimizing bitwise operations.
+isConcreteOnes :: SVal -> Bool
+isConcreteOnes (SVal _ (Left (CW (KBounded b w) (CWInteger n)))) = n == if b then -1 else bit w - 1
+isConcreteOnes (SVal _ (Left (CW KUnbounded     (CWInteger n)))) = n == -1
+isConcreteOnes (SVal _ (Left (CW KBool          (CWInteger n)))) = n == 1
+isConcreteOnes _                                                 = False
+
+-- | Predicate for optimizing comparisons.
+isConcreteMax :: SVal -> Bool
+isConcreteMax (SVal _ (Left (CW (KBounded False w) (CWInteger n)))) = n == bit w - 1
+isConcreteMax (SVal _ (Left (CW (KBounded True  w) (CWInteger n)))) = n == bit (w - 1) - 1
+isConcreteMax (SVal _ (Left (CW KBool              (CWInteger n)))) = n == 1
+isConcreteMax _                                                     = False
+
+-- | Predicate for optimizing comparisons.
+isConcreteMin :: SVal -> Bool
+isConcreteMin (SVal _ (Left (CW (KBounded False _) (CWInteger n)))) = n == 0
+isConcreteMin (SVal _ (Left (CW (KBounded True  w) (CWInteger n)))) = n == - bit (w - 1)
+isConcreteMin (SVal _ (Left (CW KBool              (CWInteger n)))) = n == 0
+isConcreteMin _                                                     = False
+
+-- | Predicate for optimizing conditionals.
+areConcretelyEqual :: SVal -> SVal -> Bool
+areConcretelyEqual (SVal _ (Left a)) (SVal _ (Left b)) = a == b
+areConcretelyEqual _                       _           = False
+
+-- Most operations on concrete rationals require a compatibility check
+rationalCheck :: CW -> CW -> Bool
+rationalCheck a b = case (cwVal a, cwVal b) of
+                     (CWAlgReal x, CWAlgReal y) -> isExactRational x && isExactRational y
+                     _                          -> True
+
+-- same as above, for SBV's
+rationalSBVCheck :: SVal -> SVal -> Bool
+rationalSBVCheck (SVal KReal (Left a)) (SVal KReal (Left b)) = rationalCheck a b
+rationalSBVCheck _                     _                     = True
+
+-- Some operations will never be used on Reals, but we need fillers:
+noReal :: String -> AlgReal -> AlgReal -> AlgReal
+noReal o a b = error $ "SBV.AlgReal." ++ o ++ ": Unexpected arguments: " ++ show (a, b)
+
+noFloat :: String -> Float -> Float -> Float
+noFloat o a b = error $ "SBV.Float." ++ o ++ ": Unexpected arguments: " ++ show (a, b)
+
+noDouble :: String -> Double -> Double -> Double
+noDouble o a b = error $ "SBV.Double." ++ o ++ ": Unexpected arguments: " ++ show (a, b)
+
+noRealUnary :: String -> AlgReal -> AlgReal
+noRealUnary o a = error $ "SBV.AlgReal." ++ o ++ ": Unexpected argument: " ++ show a
+
+noFloatUnary :: String -> Float -> Float
+noFloatUnary o a = error $ "SBV.Float." ++ o ++ ": Unexpected argument: " ++ show a
+
+noDoubleUnary :: String -> Double -> Double
+noDoubleUnary o a = error $ "SBV.Double." ++ o ++ ": Unexpected argument: " ++ show a

--- a/Data/SBV/BitVectors/Rounding.hs
+++ b/Data/SBV/BitVectors/Rounding.hs
@@ -41,7 +41,7 @@ class (SymWord a, Floating a) => RoundingFloat a where
 
 -- | Lift a 1 arg floating point UOP
 lift1Rm :: (SymWord a, Floating a) => String -> SRoundingMode -> SBV a -> SBV a
-lift1Rm w m a = SBV k $ Right $ cache r
+lift1Rm w m a = SBV $ SVal k $ Right $ cache r
   where k = kindOf a
         r st = do swm <- sbvToSW st m
                   swa <- sbvToSW st a
@@ -49,7 +49,7 @@ lift1Rm w m a = SBV k $ Right $ cache r
 
 -- | Lift a 2 arg floating point UOP
 lift2Rm :: (SymWord a, Floating a) => String -> SRoundingMode -> SBV a -> SBV a -> SBV a
-lift2Rm w m a b = SBV k $ Right $ cache r
+lift2Rm w m a b = SBV $ SVal k $ Right $ cache r
   where k = kindOf a
         r st = do swm <- sbvToSW st m
                   swa <- sbvToSW st a
@@ -58,7 +58,7 @@ lift2Rm w m a b = SBV k $ Right $ cache r
 
 -- | Lift a 3 arg floating point UOP
 lift3Rm :: (SymWord a, Floating a) => String -> SRoundingMode -> SBV a -> SBV a -> SBV a -> SBV a
-lift3Rm w m a b c = SBV k $ Right $ cache r
+lift3Rm w m a b c = SBV $ SVal k $ Right $ cache r
   where k = kindOf a
         r st = do swm <- sbvToSW st m
                   swa <- sbvToSW st a

--- a/Data/SBV/BitVectors/SignCast.hs
+++ b/Data/SBV/BitVectors/SignCast.hs
@@ -79,7 +79,7 @@ instance SignCast Word8  Int8  where
 genericSign :: (Integral a, SymWord a, Num b, SymWord b) => SBV a -> SBV b
 genericSign x
   | Just c <- unliteral x = literal $ fromIntegral c
-  | True                  = SBV k (Right (cache y))
+  | True                  = SBV (SVal k (Right (cache y)))
      where k = case kindOf x of
                  KBool            -> error "Data.SBV.SignCast.genericSign: Called on boolean value"
                  KBounded False n -> KBounded True n
@@ -96,7 +96,7 @@ genericSign x
 genericUnsign :: (Integral a, SymWord a, Num b, SymWord b) => SBV a -> SBV b
 genericUnsign x
   | Just c <- unliteral x = literal $ fromIntegral c
-  | True                  = SBV k (Right (cache y))
+  | True                  = SBV (SVal k (Right (cache y)))
      where k = case kindOf x of
                  KBool            -> error "Data.SBV.SignCast.genericUnSign: Called on boolean value"
                  KBounded True  n -> KBounded False n

--- a/Data/SBV/BitVectors/Splittable.hs
+++ b/Data/SBV/BitVectors/Splittable.hs
@@ -72,42 +72,42 @@ cwJoin x y = error $ "SBV.cwJoin: Unsupported arguments: " ++ show (x, y)
 
 -- symbolic instances
 instance Splittable SWord64 SWord32 where
-  split (SBV _ (Left z)) = cwSplit z
-  split z                = (SBV (KBounded False 32) (Right (cache x)), SBV (KBounded False 32) (Right (cache y)))
+  split (SBV (SVal _ (Left z))) = cwSplit z
+  split z                       = (SBV (SVal (KBounded False 32) (Right (cache x))), SBV (SVal (KBounded False 32) (Right (cache y))))
     where x st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 32) (SBVApp (Extract 63 32) [zsw])
           y st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 32) (SBVApp (Extract 31  0) [zsw])
-  (SBV _ (Left a)) # (SBV _ (Left b)) = cwJoin a b
-  a # b = SBV (KBounded False 64) (Right (cache c))
+  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
+  a # b = SBV (SVal (KBounded False 64) (Right (cache c)))
     where c st = do asw <- sbvToSW st a
                     bsw <- sbvToSW st b
                     newExpr st (KBounded False 64) (SBVApp Join [asw, bsw])
   extend b = 0 # b
 
 instance Splittable SWord32 SWord16 where
-  split (SBV _ (Left z)) = cwSplit z
-  split z                = (SBV (KBounded False 16) (Right (cache x)), SBV (KBounded False 16) (Right (cache y)))
+  split (SBV (SVal _ (Left z))) = cwSplit z
+  split z                       = (SBV (SVal (KBounded False 16) (Right (cache x))), SBV (SVal (KBounded False 16) (Right (cache y))))
     where x st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 16) (SBVApp (Extract 31 16) [zsw])
           y st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 16) (SBVApp (Extract 15  0) [zsw])
-  (SBV _ (Left a)) # (SBV _ (Left b)) = cwJoin a b
-  a # b = SBV (KBounded False 32) (Right (cache c))
+  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
+  a # b = SBV (SVal (KBounded False 32) (Right (cache c)))
     where c st = do asw <- sbvToSW st a
                     bsw <- sbvToSW st b
                     newExpr st (KBounded False 32) (SBVApp Join [asw, bsw])
   extend b = 0 # b
 
 instance Splittable SWord16 SWord8 where
-  split (SBV _ (Left z)) = cwSplit z
-  split z                = (SBV (KBounded False 8) (Right (cache x)), SBV (KBounded False 8) (Right (cache y)))
+  split (SBV (SVal _ (Left z))) = cwSplit z
+  split z                       = (SBV (SVal (KBounded False 8) (Right (cache x))), SBV (SVal (KBounded False 8) (Right (cache y))))
     where x st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 8) (SBVApp (Extract 15 8) [zsw])
           y st = do zsw <- sbvToSW st z
                     newExpr st (KBounded False 8) (SBVApp (Extract  7 0) [zsw])
-  (SBV _ (Left a)) # (SBV _ (Left b)) = cwJoin a b
-  a # b = SBV (KBounded False 16) (Right (cache c))
+  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
+  a # b = SBV (SVal (KBounded False 16) (Right (cache c)))
     where c st = do asw <- sbvToSW st a
                     bsw <- sbvToSW st b
                     newExpr st (KBounded False 16) (SBVApp Join [asw, bsw])

--- a/Data/SBV/BitVectors/Splittable.hs
+++ b/Data/SBV/BitVectors/Splittable.hs
@@ -20,6 +20,7 @@ module Data.SBV.BitVectors.Splittable (Splittable(..), FromBits(..), checkAndCon
 import Data.Bits (Bits(..))
 import Data.Word (Word8, Word16, Word32, Word64)
 
+import Data.SBV.BitVectors.Operations
 import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.Model
 
@@ -61,56 +62,20 @@ instance Splittable Word16 Word8 where
   (#)   = genJoin  8
   extend b = 0 # b
 
-cwSplit :: (SymWord a, Num a) => CW -> (SBV a, SBV a)
-cwSplit z@(CW _ (CWInteger v)) = (literal x, literal y)
-  where (x, y) = genSplit (intSizeOf z `div` 2) v
-cwSplit z = error $ "SBV.cwSplit: Unsupported CW value: " ++ show z
-
-cwJoin :: (SymWord a, Num a) => CW -> CW -> SBV a
-cwJoin x@(CW _ (CWInteger a)) (CW _ (CWInteger b)) = literal (genJoin (intSizeOf x) a b)
-cwJoin x y = error $ "SBV.cwJoin: Unsupported arguments: " ++ show (x, y)
-
 -- symbolic instances
 instance Splittable SWord64 SWord32 where
-  split (SBV (SVal _ (Left z))) = cwSplit z
-  split z                       = (SBV (SVal (KBounded False 32) (Right (cache x))), SBV (SVal (KBounded False 32) (Right (cache y))))
-    where x st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 32) (SBVApp (Extract 63 32) [zsw])
-          y st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 32) (SBVApp (Extract 31  0) [zsw])
-  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
-  a # b = SBV (SVal (KBounded False 64) (Right (cache c)))
-    where c st = do asw <- sbvToSW st a
-                    bsw <- sbvToSW st b
-                    newExpr st (KBounded False 64) (SBVApp Join [asw, bsw])
+  split (SBV x) = (SBV (svExtract 63 32 x), SBV (svExtract 31 0 x))
+  SBV a # SBV b = SBV (svJoin a b)
   extend b = 0 # b
 
 instance Splittable SWord32 SWord16 where
-  split (SBV (SVal _ (Left z))) = cwSplit z
-  split z                       = (SBV (SVal (KBounded False 16) (Right (cache x))), SBV (SVal (KBounded False 16) (Right (cache y))))
-    where x st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 16) (SBVApp (Extract 31 16) [zsw])
-          y st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 16) (SBVApp (Extract 15  0) [zsw])
-  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
-  a # b = SBV (SVal (KBounded False 32) (Right (cache c)))
-    where c st = do asw <- sbvToSW st a
-                    bsw <- sbvToSW st b
-                    newExpr st (KBounded False 32) (SBVApp Join [asw, bsw])
+  split (SBV x) = (SBV (svExtract 31 16 x), SBV (svExtract 15 0 x))
+  SBV a # SBV b = SBV (svJoin a b)
   extend b = 0 # b
 
 instance Splittable SWord16 SWord8 where
-  split (SBV (SVal _ (Left z))) = cwSplit z
-  split z                       = (SBV (SVal (KBounded False 8) (Right (cache x))), SBV (SVal (KBounded False 8) (Right (cache y))))
-    where x st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 8) (SBVApp (Extract 15 8) [zsw])
-          y st = do zsw <- sbvToSW st z
-                    newExpr st (KBounded False 8) (SBVApp (Extract  7 0) [zsw])
-  (SBV (SVal _ (Left a))) # (SBV (SVal _ (Left b))) = cwJoin a b
-  a # b = SBV (SVal (KBounded False 16) (Right (cache c)))
-    where c st = do asw <- sbvToSW st a
-                    bsw <- sbvToSW st b
-                    newExpr st (KBounded False 16) (SBVApp Join [asw, bsw])
+  split (SBV x) = (SBV (svExtract 15 8 x), SBV (svExtract 7 0 x))
+  SBV a # SBV b = SBV (svJoin a b)
   extend b = 0 # b
 
 -- | Unblasting a value from symbolic-bits. The bits can be given little-endian

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -24,12 +24,12 @@
 
 module Data.SBV.BitVectors.Symbolic
   ( NodeId(..)
-  , SW(..), trueSW, falseSW
+  , SW(..), swKind, trueSW, falseSW
   , Op(..), smtLibSquareRoot, smtLibFusedMA
   , Quantifier(..), needsExistentials
   , RoundingMode(..)
   , SBVType(..), newUninterpreted, unintFnUIKind, addAxiom
-  , SVal(..)
+  , SVal(..), svKind
   , mkSValWithRandom
   , ArrayContext(..), ArrayInfo, arrayUIKind
   , svToSW, forceSWArg
@@ -403,6 +403,9 @@ getSBranchRunConfig st = case runMode st of
 -- value (@Right Cached@). Note that caching is essential for making
 -- sure sharing is preserved.
 data SVal = SVal !Kind !(Either CW (Cached SW))
+
+svKind :: SVal -> Kind
+svKind (SVal k _) = k
 
 -- Not particularly "desirable", but will do if needed
 instance Show SVal where

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -1,0 +1,1004 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.BitVectors.Symbolic
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Symbolic values
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE    GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE    TypeSynonymInstances       #-}
+{-# LANGUAGE    TypeOperators              #-}
+{-# LANGUAGE    MultiParamTypeClasses      #-}
+{-# LANGUAGE    ScopedTypeVariables        #-}
+{-# LANGUAGE    FlexibleInstances          #-}
+{-# LANGUAGE    PatternGuards              #-}
+{-# LANGUAGE    StandaloneDeriving         #-}
+{-# LANGUAGE    DefaultSignatures          #-}
+{-# LANGUAGE    NamedFieldPuns             #-}
+{-# LANGUAGE    DeriveDataTypeable         #-}
+{-# OPTIONS_GHC -fno-warn-orphans          #-}
+
+module Data.SBV.BitVectors.Symbolic
+  ( NodeId(..)
+  , SW(..), trueSW, falseSW
+  , Op(..), smtLibSquareRoot, smtLibFusedMA
+  , Quantifier(..), needsExistentials
+  , RoundingMode(..)
+  , SBVType(..), newUninterpreted, unintFnUIKind, addAxiom
+  , SVal(..)
+  , mkSValWithRandom
+  , ArrayContext(..), ArrayInfo, arrayUIKind
+  , svToSW, forceSWArg
+  , SBVExpr(..), newExpr
+  , Cached, cache, uncache
+  , ArrayIndex, uncacheAI
+  , NamedSymVar
+  , UnintKind(..)
+  , getSValPathCondition, extendSValPathCondition
+  , getTableIndex
+  , SBVPgm(..), Symbolic, runSymbolic, runSymbolic', State
+  , inProofMode, SBVRunMode(..), Result(..)
+  , Logic(..), SMTLibLogic(..)
+  , getTraceInfo, getConstraints
+  , addSValConstraint
+  , SMTLibPgm(..), SMTLibVersion(..)
+  , SolverCapabilities(..)
+  , extractSymbolicSimulationState
+  , SMTScript(..), Solver(..), SMTSolver(..), SMTResult(..), SMTModel(..), SMTConfig(..), getSBranchRunConfig
+  , outputSVal
+  , mkSValUserSort
+  , SArr(..), readSArr, resetSArr, writeSArr, mergeSArr, newSArr, eqSArr
+  ) where
+
+import Control.DeepSeq      (NFData(..))
+import Control.Applicative  (Applicative)
+import Control.Monad        (when)
+import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
+import Control.Monad.Trans  (MonadIO, liftIO)
+import Data.Char            (isAlpha, isAlphaNum)
+import Data.IORef           (IORef, newIORef, modifyIORef, readIORef, writeIORef)
+import Data.List            (intercalate, sortBy)
+import Data.Maybe           (isJust, fromJust)
+
+import qualified Data.Generics as G    (Data(..))
+import qualified Data.Typeable as T    (Typeable)
+import qualified Data.IntMap   as IMap (IntMap, empty, size, toAscList, lookup, insert, insertWith)
+import qualified Data.Map      as Map  (Map, empty, toList, size, insert, lookup)
+import qualified Data.Set      as Set  (Set, empty, toList, insert)
+import qualified Data.Foldable as F    (toList)
+import qualified Data.Sequence as S    (Seq, empty, (|>))
+
+import System.Exit           (ExitCode(..))
+import System.Mem.StableName
+import System.Random
+
+import Data.SBV.BitVectors.AlgReals
+import Data.SBV.Utils.Lib
+
+import Data.SBV.BitVectors.Kind
+import Data.SBV.BitVectors.Concrete
+
+-- | A symbolic node id
+newtype NodeId = NodeId Int deriving (Eq, Ord)
+
+-- | A symbolic word, tracking it's signedness and size.
+data SW = SW Kind NodeId deriving (Eq, Ord)
+
+instance Show SW where
+  show (SW _ (NodeId n))
+    | n < 0 = "s_" ++ show (abs n)
+    | True  = 's' : show n
+
+swKind :: SW -> Kind
+swKind (SW k _) = k
+
+-- | Forcing an argument; this is a necessary evil to make sure all the arguments
+-- to an uninterpreted function and sBranch test conditions are evaluated before called;
+-- the semantics of uinterpreted functions is necessarily strict; deviating from Haskell's
+forceSWArg :: SW -> IO ()
+forceSWArg (SW k n) = k `seq` n `seq` return ()
+
+-- | Constant False as a SW. Note that this value always occupies slot -2.
+falseSW :: SW
+falseSW = SW KBool $ NodeId (-2)
+
+-- | Constant False as a SW. Note that this value always occupies slot -1.
+trueSW :: SW
+trueSW  = SW KBool $ NodeId (-1)
+
+-- | Symbolic operations
+data Op = Plus | Times | Minus | UNeg | Abs
+        | Quot | Rem
+        | Equal | NotEqual
+        | LessThan | GreaterThan | LessEq | GreaterEq
+        | Ite
+        | And | Or  | XOr | Not
+        | Shl Int | Shr Int | Rol Int | Ror Int
+        | Extract Int Int -- Extract i j: extract bits i to j. Least significant bit is 0 (big-endian)
+        | Join  -- Concat two words to form a bigger one, in the order given
+        | LkUp (Int, Kind, Kind, Int) !SW !SW   -- (table-index, arg-type, res-type, length of the table) index out-of-bounds-value
+        | ArrEq   Int Int
+        | ArrRead Int
+        | Uninterpreted String
+        -- Floating point uops with custom rounding-modes
+        | FPRound String
+        deriving (Eq, Ord)
+
+-- | SMT-Lib's square-root over floats/doubles. We piggy back on to the uninterpreted function mechanism
+-- to implement these; which is not a terrible idea; although the use of the constructor 'Uninterpreted'
+-- might be confusing. This function will *not* be uninterpreted in reality, as QF_FP will define it. It's
+-- a bit of a shame, but much easier to implement it this way.
+smtLibSquareRoot :: Op
+smtLibSquareRoot = Uninterpreted "fp.sqrt"
+
+-- | SMT-Lib's fusedMA over floats/doubles. Similar to the 'smtLibSquareRoot'. Note that we cannot implement
+-- this function in Haskell as precision loss would be inevitable. Maybe Haskell will eventually add this op
+-- to the Num class.
+smtLibFusedMA :: Op
+smtLibFusedMA = Uninterpreted "fp.fma"
+
+instance Show Op where
+  show (Shl i) = "<<"  ++ show i
+  show (Shr i) = ">>"  ++ show i
+  show (Rol i) = "<<<" ++ show i
+  show (Ror i) = ">>>" ++ show i
+  show (Extract i j) = "choose [" ++ show i ++ ":" ++ show j ++ "]"
+  show (LkUp (ti, at, rt, l) i e)
+        = "lookup(" ++ tinfo ++ ", " ++ show i ++ ", " ++ show e ++ ")"
+        where tinfo = "table" ++ show ti ++ "(" ++ show at ++ " -> " ++ show rt ++ ", " ++ show l ++ ")"
+  show (ArrEq i j)   = "array_" ++ show i ++ " == array_" ++ show j
+  show (ArrRead i)   = "select array_" ++ show i
+  show (Uninterpreted i) = "[uninterpreted] " ++ i
+  show (FPRound w)       = w
+  show op
+    | Just s <- op `lookup` syms = s
+    | True                       = error "impossible happened; can't find op!"
+    where syms = [ (Plus, "+"), (Times, "*"), (Minus, "-"), (UNeg, "-"), (Abs, "abs")
+                 , (Quot, "quot")
+                 , (Rem,  "rem")
+                 , (Equal, "=="), (NotEqual, "/=")
+                 , (LessThan, "<"), (GreaterThan, ">"), (LessEq, "<"), (GreaterEq, ">")
+                 , (Ite, "if_then_else")
+                 , (And, "&"), (Or, "|"), (XOr, "^"), (Not, "~")
+                 , (Join, "#")
+                 ]
+
+-- | Quantifiers: forall or exists. Note that we allow
+-- arbitrary nestings.
+data Quantifier = ALL | EX deriving Eq
+
+-- | Are there any existential quantifiers?
+needsExistentials :: [Quantifier] -> Bool
+needsExistentials = (EX `elem`)
+
+-- | A simple type for SBV computations, used mainly for uninterpreted constants.
+-- We keep track of the signedness/size of the arguments. A non-function will
+-- have just one entry in the list.
+newtype SBVType = SBVType [Kind]
+             deriving (Eq, Ord)
+
+-- | how many arguments does the type take?
+typeArity :: SBVType -> Int
+typeArity (SBVType xs) = length xs - 1
+
+instance Show SBVType where
+  show (SBVType []) = error "SBV: internal error, empty SBVType"
+  show (SBVType xs) = intercalate " -> " $ map show xs
+
+-- | A symbolic expression
+data SBVExpr = SBVApp !Op ![SW]
+             deriving (Eq, Ord)
+
+-- | To improve hash-consing, take advantage of commutative operators by
+-- reordering their arguments.
+reorder :: SBVExpr -> SBVExpr
+reorder s = case s of
+              SBVApp op [a, b] | isCommutative op && a > b -> SBVApp op [b, a]
+              _ -> s
+  where isCommutative :: Op -> Bool
+        isCommutative o = o `elem` [Plus, Times, Equal, NotEqual, And, Or, XOr]
+
+instance Show SBVExpr where
+  show (SBVApp Ite [t, a, b]) = unwords ["if", show t, "then", show a, "else", show b]
+  show (SBVApp (Shl i) [a])   = unwords [show a, "<<", show i]
+  show (SBVApp (Shr i) [a])   = unwords [show a, ">>", show i]
+  show (SBVApp (Rol i) [a])   = unwords [show a, "<<<", show i]
+  show (SBVApp (Ror i) [a])   = unwords [show a, ">>>", show i]
+  show (SBVApp op  [a, b])    = unwords [show a, show op, show b]
+  show (SBVApp op  args)      = unwords (show op : map show args)
+
+-- | A program is a sequence of assignments
+newtype SBVPgm = SBVPgm {pgmAssignments :: (S.Seq (SW, SBVExpr))}
+
+-- | 'NamedSymVar' pairs symbolic words and user given/automatically generated names
+type NamedSymVar = (SW, String)
+
+-- | 'UnintKind' pairs array names and uninterpreted constants with their "kinds"
+-- used mainly for printing counterexamples
+data UnintKind = UFun Int String | UArr Int String      -- in each case, arity and the aliasing name
+ deriving Show
+
+-- | Result of running a symbolic computation
+data Result = Result (Set.Set Kind)                -- kinds used in the program
+                     [(String, CW)]                -- quick-check counter-example information (if any)
+                     [(String, [String])]          -- uninterpeted code segments
+                     [(Quantifier, NamedSymVar)]   -- inputs (possibly existential)
+                     [(SW, CW)]                    -- constants
+                     [((Int, Kind, Kind), [SW])]   -- tables (automatically constructed) (tableno, index-type, result-type) elts
+                     [(Int, ArrayInfo)]            -- arrays (user specified)
+                     [(String, SBVType)]           -- uninterpreted constants
+                     [(String, [String])]          -- axioms
+                     SBVPgm                        -- assignments
+                     [SW]                          -- additional constraints (boolean)
+                     [SW]                          -- outputs
+
+-- | Extract the constraints from a result
+getConstraints :: Result -> [SW]
+getConstraints (Result _ _ _ _ _ _ _ _ _ _ cstrs _) = cstrs
+
+-- | Extract the traced-values from a result (quick-check)
+getTraceInfo :: Result -> [(String, CW)]
+getTraceInfo (Result _ tvals _ _ _ _ _ _ _ _ _ _) = tvals
+
+instance Show Result where
+  show (Result _ _ _ _ cs _ _ [] [] _ [] [r])
+    | Just c <- r `lookup` cs
+    = show c
+  show (Result kinds _ cgs is cs ts as uis axs xs cstrs os)  = intercalate "\n" $
+                   (if null usorts then [] else "SORTS" : map ("  " ++) usorts)
+                ++ ["INPUTS"]
+                ++ map shn is
+                ++ ["CONSTANTS"]
+                ++ map shc cs
+                ++ ["TABLES"]
+                ++ map sht ts
+                ++ ["ARRAYS"]
+                ++ map sha as
+                ++ ["UNINTERPRETED CONSTANTS"]
+                ++ map shui uis
+                ++ ["USER GIVEN CODE SEGMENTS"]
+                ++ concatMap shcg cgs
+                ++ ["AXIOMS"]
+                ++ map shax axs
+                ++ ["DEFINE"]
+                ++ map (\(s, e) -> "  " ++ shs s ++ " = " ++ show e) (F.toList (pgmAssignments xs))
+                ++ ["CONSTRAINTS"]
+                ++ map (("  " ++) . show) cstrs
+                ++ ["OUTPUTS"]
+                ++ map (("  " ++) . show) os
+    where usorts = [sh s t | KUserSort s t <- Set.toList kinds]
+                   where sh s (Left   _, _) = s
+                         sh s (Right es, _) = s ++ " (" ++ intercalate ", " es ++ ")"
+          shs sw = show sw ++ " :: " ++ show (swKind sw)
+          sht ((i, at, rt), es)  = "  Table " ++ show i ++ " : " ++ show at ++ "->" ++ show rt ++ " = " ++ show es
+          shc (sw, cw) = "  " ++ show sw ++ " = " ++ show cw
+          shcg (s, ss) = ("Variable: " ++ s) : map ("  " ++) ss
+          shn (q, (sw, nm)) = "  " ++ ni ++ " :: " ++ show (swKind sw) ++ ex ++ alias
+            where ni = show sw
+                  ex | q == ALL = ""
+                     | True     = ", existential"
+                  alias | ni == nm = ""
+                        | True     = ", aliasing " ++ show nm
+          sha (i, (nm, (ai, bi), ctx)) = "  " ++ ni ++ " :: " ++ show ai ++ " -> " ++ show bi ++ alias
+                                       ++ "\n     Context: "     ++ show ctx
+            where ni = "array_" ++ show i
+                  alias | ni == nm = ""
+                        | True     = ", aliasing " ++ show nm
+          shui (nm, t) = "  [uninterpreted] " ++ nm ++ " :: " ++ show t
+          shax (nm, ss) = "  -- user defined axiom: " ++ nm ++ "\n  " ++ intercalate "\n  " ss
+
+-- | The context of a symbolic array as created
+data ArrayContext = ArrayFree (Maybe SW)     -- ^ A new array, with potential initializer for each cell
+                  | ArrayReset Int SW        -- ^ An array created from another array by fixing each element to another value
+                  | ArrayMutate Int SW SW    -- ^ An array created by mutating another array at a given cell
+                  | ArrayMerge  SW Int Int   -- ^ An array created by symbolically merging two other arrays
+
+instance Show ArrayContext where
+  show (ArrayFree Nothing)  = " initialized with random elements"
+  show (ArrayFree (Just s)) = " initialized with " ++ show s ++ " :: " ++ show (swKind s)
+  show (ArrayReset i s)     = " reset array_" ++ show i ++ " with " ++ show s ++ " :: " ++ show (swKind s)
+  show (ArrayMutate i a b)  = " cloned from array_" ++ show i ++ " with " ++ show a ++ " :: " ++ show (swKind a) ++ " |-> " ++ show b ++ " :: " ++ show (swKind b)
+  show (ArrayMerge s i j)   = " merged arrays " ++ show i ++ " and " ++ show j ++ " on condition " ++ show s
+
+-- | Expression map, used for hash-consing
+type ExprMap   = Map.Map SBVExpr SW
+
+-- | Constants are stored in a map, for hash-consing
+type CnstMap   = Map.Map CW SW
+
+-- | Kinds used in the program; used for determining the final SMT-Lib logic to pick
+type KindSet = Set.Set Kind
+
+-- | Tables generated during a symbolic run
+type TableMap  = Map.Map [SW] (Int, Kind, Kind)
+
+-- | Representation for symbolic arrays
+type ArrayInfo = (String, (Kind, Kind), ArrayContext)
+
+-- | Arrays generated during a symbolic run
+type ArrayMap  = IMap.IntMap ArrayInfo
+
+-- | Uninterpreted-constants generated during a symbolic run
+type UIMap     = Map.Map String SBVType
+
+-- | Code-segments for Uninterpreted-constants, as given by the user
+type CgMap     = Map.Map String [String]
+
+-- | Cached values, implementing sharing
+type Cache a   = IMap.IntMap [(StableName (State -> IO a), a)]
+
+-- | Convert an SBV-type to the kind-of uninterpreted value it represents
+unintFnUIKind :: (String, SBVType) -> (String, UnintKind)
+unintFnUIKind (s, t) = (s, UFun (typeArity t) s)
+
+-- | Convert an array value type to the kind-of uninterpreted value it represents
+arrayUIKind :: (Int, ArrayInfo) -> Maybe (String, UnintKind)
+arrayUIKind (i, (nm, _, ctx))
+  | external ctx = Just ("array_" ++ show i, UArr 1 nm) -- arrays are always 1-dimensional in the SMT-land. (Unless encoded explicitly)
+  | True         = Nothing
+  where external (ArrayFree{})   = True
+        external (ArrayReset{})  = False
+        external (ArrayMutate{}) = False
+        external (ArrayMerge{})  = False
+
+-- | Different means of running a symbolic piece of code
+data SBVRunMode = Proof (Bool, Maybe SMTConfig) -- ^ Symbolic simulation mode, for proof purposes. Bool is True if it's a sat instance. SMTConfig is used for 'sBranch' calls.
+                | CodeGen                       -- ^ Code generation mode
+                | Concrete StdGen               -- ^ Concrete simulation mode. The StdGen is for the pConstrain acceptance in cross runs
+
+-- | Is this a concrete run? (i.e., quick-check or test-generation like)
+isConcreteMode :: SBVRunMode -> Bool
+isConcreteMode (Concrete _) = True
+isConcreteMode (Proof{})    = False
+isConcreteMode CodeGen      = False
+
+-- | The state of the symbolic interpreter
+data State  = State { runMode       :: SBVRunMode
+                    , pathCond      :: SVal -- ^ kind KBool
+                    , rStdGen       :: IORef StdGen
+                    , rCInfo        :: IORef [(String, CW)]
+                    , rctr          :: IORef Int
+                    , rUsedKinds    :: IORef KindSet
+                    , rinps         :: IORef [(Quantifier, NamedSymVar)]
+                    , rConstraints  :: IORef [SW]
+                    , routs         :: IORef [SW]
+                    , rtblMap       :: IORef TableMap
+                    , spgm          :: IORef SBVPgm
+                    , rconstMap     :: IORef CnstMap
+                    , rexprMap      :: IORef ExprMap
+                    , rArrayMap     :: IORef ArrayMap
+                    , rUIMap        :: IORef UIMap
+                    , rCgMap        :: IORef CgMap
+                    , raxioms       :: IORef [(String, [String])]
+                    , rSWCache      :: IORef (Cache SW)
+                    , rAICache      :: IORef (Cache Int)
+                    }
+
+-- | Get the current path condition
+getSValPathCondition :: State -> SVal
+getSValPathCondition = pathCond
+
+-- | Extend the path condition with the given test value.
+extendSValPathCondition :: State -> (SVal -> SVal) -> State
+extendSValPathCondition st f = st{pathCond = f (pathCond st)}
+
+-- | Are we running in proof mode?
+inProofMode :: State -> Bool
+inProofMode s = case runMode s of
+                  Proof{}    -> True
+                  CodeGen    -> False
+                  Concrete{} -> False
+
+-- | If in proof mode, get the underlying configuration (used for 'sBranch')
+getSBranchRunConfig :: State -> Maybe SMTConfig
+getSBranchRunConfig st = case runMode st of
+                           Proof (_, s)  -> s
+                           _             -> Nothing
+
+-- | The "Symbolic" value. Either a constant (@Left@) or a symbolic
+-- value (@Right Cached@). Note that caching is essential for making
+-- sure sharing is preserved.
+data SVal = SVal !Kind !(Either CW (Cached SW))
+
+-- Not particularly "desirable", but will do if needed
+instance Show SVal where
+  show (SVal _ (Left c))  = show c
+  show (SVal k (Right _)) = "<symbolic> :: " ++ show k
+
+-- Equality constraint on SBV values. Not desirable since we can't really compare two
+-- symbolic values, but will do.
+instance Eq SVal where
+  SVal _ (Left a) == SVal _ (Left b) = a == b
+  a == b = error $ "Comparing symbolic bit-vectors; Use (.==) instead. Received: " ++ show (a, b)
+  SVal _ (Left a) /= SVal _ (Left b) = a /= b
+  a /= b = error $ "Comparing symbolic bit-vectors; Use (./=) instead. Received: " ++ show (a, b)
+
+-- | Increment the variable counter
+incCtr :: State -> IO Int
+incCtr s = do ctr <- readIORef (rctr s)
+              let i = ctr + 1
+              i `seq` writeIORef (rctr s) i
+              return ctr
+
+-- | Generate a random value, for quick-check and test-gen purposes
+throwDice :: State -> IO Double
+throwDice st = do g <- readIORef (rStdGen st)
+                  let (r, g') = randomR (0, 1) g
+                  writeIORef (rStdGen st) g'
+                  return r
+
+-- | Create a new uninterpreted symbol, possibly with user given code
+newUninterpreted :: State -> String -> SBVType -> Maybe [String] -> IO ()
+newUninterpreted st nm t mbCode
+  | null nm || not (isAlpha (head nm)) || not (all validChar (tail nm))
+  = error $ "Bad uninterpreted constant name: " ++ show nm ++ ". Must be a valid identifier."
+  | True = do
+        uiMap <- readIORef (rUIMap st)
+        case nm `Map.lookup` uiMap of
+          Just t' -> if t /= t'
+                     then error $  "Uninterpreted constant " ++ show nm ++ " used at incompatible types\n"
+                                ++ "      Current type      : " ++ show t ++ "\n"
+                                ++ "      Previously used at: " ++ show t'
+                     else return ()
+          Nothing -> do modifyIORef (rUIMap st) (Map.insert nm t)
+                        when (isJust mbCode) $ modifyIORef (rCgMap st) (Map.insert nm (fromJust mbCode))
+  where validChar x = isAlphaNum x || x `elem` "_"
+
+-- | Create a new SW
+newSW :: State -> Kind -> IO (SW, String)
+newSW st k = do ctr <- incCtr st
+                let sw = SW k (NodeId ctr)
+                registerKind st k
+                return (sw, 's' : show ctr)
+{-# INLINE newSW #-}
+
+registerKind :: State -> Kind -> IO ()
+registerKind st k
+  | KUserSort sortName _ <- k, sortName `elem` reserved
+  = error $ "SBV: " ++ show sortName ++ " is a reserved sort; please use a different name."
+  | True
+  = modifyIORef (rUsedKinds st) (Set.insert k)
+ where -- TODO: this list is not comprehensive!
+       reserved = ["Int", "Real", "List", "Array", "Bool", "NUMERAL", "DECIMAL", "STRING", "FP", "FloatingPoint", "fp"]  -- Reserved by SMT-Lib
+
+-- | Create a new constant; hash-cons as necessary
+newConst :: State -> CW -> IO SW
+newConst st c = do
+  constMap <- readIORef (rconstMap st)
+  case c `Map.lookup` constMap of
+    Just sw -> return sw
+    Nothing -> do let k = cwKind c
+                  (sw, _) <- newSW st k
+                  modifyIORef (rconstMap st) (Map.insert c sw)
+                  return sw
+{-# INLINE newConst #-}
+
+-- | Create a new table; hash-cons as necessary
+getTableIndex :: State -> Kind -> Kind -> [SW] -> IO Int
+getTableIndex st at rt elts = do
+  tblMap <- readIORef (rtblMap st)
+  case elts `Map.lookup` tblMap of
+    Just (i, _, _)  -> return i
+    Nothing         -> do let i = Map.size tblMap
+                          modifyIORef (rtblMap st) (Map.insert elts (i, at, rt))
+                          return i
+
+-- | Create a new expression; hash-cons as necessary
+newExpr :: State -> Kind -> SBVExpr -> IO SW
+newExpr st k app = do
+   let e = reorder app
+   exprMap <- readIORef (rexprMap st)
+   case e `Map.lookup` exprMap of
+     Just sw -> return sw
+     Nothing -> do (sw, _) <- newSW st k
+                   modifyIORef (spgm st)     (\(SBVPgm xs) -> SBVPgm (xs S.|> (sw, e)))
+                   modifyIORef (rexprMap st) (Map.insert e sw)
+                   return sw
+{-# INLINE newExpr #-}
+
+-- | Convert a symbolic value to a symbolic-word
+svToSW :: State -> SVal -> IO SW
+svToSW st (SVal _ (Left c))  = newConst st c
+svToSW st (SVal _ (Right f)) = uncache f st
+
+-------------------------------------------------------------------------
+-- * Symbolic Computations
+-------------------------------------------------------------------------
+-- | A Symbolic computation. Represented by a reader monad carrying the
+-- state of the computation, layered on top of IO for creating unique
+-- references to hold onto intermediate results.
+newtype Symbolic a = Symbolic (ReaderT State IO a)
+                   deriving (Applicative, Functor, Monad, MonadIO, MonadReader State)
+
+-- | Create a symbolic value, based on the quantifier we have. If an explicit quantifier is given, we just use that.
+-- If not, then we pick existential for SAT calls and universal for everything else. The @rand@ argument is used
+-- in generating random values for this variable when used for 'quickCheck' purposes.
+mkSValWithRandom :: IO SVal -> Maybe Quantifier -> Kind -> Maybe String -> Symbolic SVal
+mkSValWithRandom rand mbQ k mbNm = do
+        st <- ask
+        let q = case (mbQ, runMode st) of
+                  (Just x,  _)                -> x   -- user given, just take it
+                  (Nothing, Concrete{})       -> ALL -- concrete simulation, pick universal
+                  (Nothing, Proof (True, _))  -> EX  -- sat mode, pick existential
+                  (Nothing, Proof (False, _)) -> ALL -- proof mode, pick universal
+                  (Nothing, CodeGen)          -> ALL -- code generation, pick universal
+        case runMode st of
+          Concrete _ | q == EX -> case mbNm of
+                                    Nothing -> error $ "Cannot quick-check in the presence of existential variables, type: " ++ show k
+                                    Just nm -> error $ "Cannot quick-check in the presence of existential variable " ++ nm ++ " :: " ++ show k
+          Concrete _           -> do v@(SVal _ (Left cw)) <- liftIO rand
+                                     liftIO $ modifyIORef (rCInfo st) ((maybe "_" id mbNm, cw):)
+                                     return v
+          _          -> do (sw, internalName) <- liftIO $ newSW st k
+                           let nm = maybe internalName id mbNm
+                           liftIO $ modifyIORef (rinps st) ((q, (sw, nm)):)
+                           return $ SVal k $ Right $ cache (const (return sw))
+
+mkSValUserSort :: Kind -> Maybe Quantifier -> Maybe String -> Symbolic SVal
+mkSValUserSort k mbQ mbNm = do
+        st <- ask
+        let (KUserSort sortName _) = k
+        liftIO $ registerKind st k
+        let q = case (mbQ, runMode st) of
+                  (Just x,  _)                -> x
+                  (Nothing, Proof (True, _))  -> EX
+                  (Nothing, Proof (False, _)) -> ALL
+                  (Nothing, Concrete{})       -> error $ "SBV: Uninterpreted sort " ++ sortName ++ " can not be used in concrete simulation mode."
+                  (Nothing, CodeGen)          -> error $ "SBV: Uninterpreted sort " ++ sortName ++ " can not be used in code-generation mode."
+        ctr <- liftIO $ incCtr st
+        let sw = SW k (NodeId ctr)
+            nm = maybe ('s':show ctr) id mbNm
+        liftIO $ modifyIORef (rinps st) ((q, (sw, nm)):)
+        return $ SVal k $ Right $ cache (const (return sw))
+
+-- | Add a user specified axiom to the generated SMT-Lib file. The first argument is a mere
+-- string, use for commenting purposes. The second argument is intended to hold the multiple-lines
+-- of the axiom text as expressed in SMT-Lib notation. Note that we perform no checks on the axiom
+-- itself, to see whether it's actually well-formed or is sensical by any means.
+-- A separate formalization of SMT-Lib would be very useful here.
+addAxiom :: String -> [String] -> Symbolic ()
+addAxiom nm ax = do
+        st <- ask
+        liftIO $ modifyIORef (raxioms st) ((nm, ax) :)
+
+-- | Run a symbolic computation in Proof mode and return a 'Result'. The boolean
+-- argument indicates if this is a sat instance or not.
+runSymbolic :: (Bool, Maybe SMTConfig) -> Symbolic a -> IO Result
+runSymbolic b c = snd `fmap` runSymbolic' (Proof b) c
+
+-- | Run a symbolic computation, and return a extra value paired up with the 'Result'
+runSymbolic' :: SBVRunMode -> Symbolic a -> IO (a, Result)
+runSymbolic' currentRunMode (Symbolic c) = do
+   ctr       <- newIORef (-2) -- start from -2; False and True will always occupy the first two elements
+   cInfo     <- newIORef []
+   pgm       <- newIORef (SBVPgm S.empty)
+   emap      <- newIORef Map.empty
+   cmap      <- newIORef Map.empty
+   inps      <- newIORef []
+   outs      <- newIORef []
+   tables    <- newIORef Map.empty
+   arrays    <- newIORef IMap.empty
+   uis       <- newIORef Map.empty
+   cgs       <- newIORef Map.empty
+   axioms    <- newIORef []
+   swCache   <- newIORef IMap.empty
+   aiCache   <- newIORef IMap.empty
+   usedKinds <- newIORef Set.empty
+   cstrs     <- newIORef []
+   rGen      <- case currentRunMode of
+                  Concrete g -> newIORef g
+                  _          -> newStdGen >>= newIORef
+   let st = State { runMode      = currentRunMode
+                  , pathCond     = SVal KBool (Left trueCW)
+                  , rStdGen      = rGen
+                  , rCInfo       = cInfo
+                  , rctr         = ctr
+                  , rUsedKinds   = usedKinds
+                  , rinps        = inps
+                  , routs        = outs
+                  , rtblMap      = tables
+                  , spgm         = pgm
+                  , rconstMap    = cmap
+                  , rArrayMap    = arrays
+                  , rexprMap     = emap
+                  , rUIMap       = uis
+                  , rCgMap       = cgs
+                  , raxioms      = axioms
+                  , rSWCache     = swCache
+                  , rAICache     = aiCache
+                  , rConstraints = cstrs
+                  }
+   _ <- newConst st falseCW -- s(-2) == falseSW
+   _ <- newConst st trueCW  -- s(-1) == trueSW
+   r <- runReaderT c st
+   res <- extractSymbolicSimulationState st
+   return (r, res)
+
+-- | Grab the program from a running symbolic simulation state. This is useful for internal purposes, for
+-- instance when implementing 'sBranch'.
+extractSymbolicSimulationState :: State -> IO Result
+extractSymbolicSimulationState st@State{ spgm=pgm, rinps=inps, routs=outs, rtblMap=tables, rArrayMap=arrays, rUIMap=uis, raxioms=axioms
+                                       , rUsedKinds=usedKinds, rCgMap=cgs, rCInfo=cInfo, rConstraints = cstrs} = do
+   SBVPgm rpgm  <- readIORef pgm
+   inpsO <- reverse `fmap` readIORef inps
+   outsO <- reverse `fmap` readIORef outs
+   let swap (a, b) = (b, a)
+       cmp  (a, _) (b, _) = a `compare` b
+   cnsts <- (sortBy cmp . map swap . Map.toList) `fmap` readIORef (rconstMap st)
+   tbls  <- (sortBy (\((x, _, _), _) ((y, _, _), _) -> x `compare` y) . map swap . Map.toList) `fmap` readIORef tables
+   arrs  <- IMap.toAscList `fmap` readIORef arrays
+   unint <- Map.toList `fmap` readIORef uis
+   axs   <- reverse `fmap` readIORef axioms
+   knds  <- readIORef usedKinds
+   cgMap <- Map.toList `fmap` readIORef cgs
+   traceVals <- reverse `fmap` readIORef cInfo
+   extraCstrs <- reverse `fmap` readIORef cstrs
+   return $ Result knds traceVals cgMap inpsO cnsts tbls arrs unint axs (SBVPgm rpgm) extraCstrs outsO
+
+-- | Handling constraints
+imposeConstraint :: SVal -> Symbolic ()
+imposeConstraint c = do st <- ask
+                        case runMode st of
+                          CodeGen -> error "SBV: constraints are not allowed in code-generation"
+                          _       -> do liftIO $ do v <- svToSW st c
+                                                    modifyIORef (rConstraints st) (v:)
+
+-- | Add a constraint with a given probability
+addSValConstraint :: Maybe Double -> SVal -> SVal -> Symbolic ()
+addSValConstraint Nothing  c _  = imposeConstraint c
+addSValConstraint (Just t) c c'
+  | t < 0 || t > 1
+  = error $ "SBV: pConstrain: Invalid probability threshold: " ++ show t ++ ", must be in [0, 1]."
+  | True
+  = do st <- ask
+       when (not (isConcreteMode (runMode st))) $ error "SBV: pConstrain only allowed in 'genTest' or 'quickCheck' contexts."
+       case () of
+         () | t > 0 && t < 1 -> liftIO (throwDice st) >>= \d -> imposeConstraint (if d <= t then c else c')
+            | t > 0          -> imposeConstraint c
+            | True           -> imposeConstraint c'
+
+-- | Mark an interim result as an output. Useful when constructing Symbolic programs
+-- that return multiple values, or when the result is programmatically computed.
+outputSVal :: SVal -> Symbolic ()
+outputSVal (SVal _ (Left c)) = do
+  st <- ask
+  sw <- liftIO $ newConst st c
+  liftIO $ modifyIORef (routs st) (sw:)
+outputSVal (SVal _ (Right f)) = do
+  st <- ask
+  sw <- liftIO $ uncache f st
+  liftIO $ modifyIORef (routs st) (sw:)
+
+---------------------------------------------------------------------------------
+-- * Symbolic Arrays
+---------------------------------------------------------------------------------
+
+-- | Arrays implemented in terms of SMT-arrays: <http://smtlib.cs.uiowa.edu/theories/ArraysEx.smt2>
+--
+--   * Maps directly to SMT-lib arrays
+--
+--   * Reading from an unintialized value is OK and yields an unspecified result
+--
+--   * Can check for equality of these arrays
+--
+--   * Cannot quick-check theorems using @SArr@ values
+--
+--   * Typically slower as it heavily relies on SMT-solving for the array theory
+--
+
+data SArr = SArr (Kind, Kind) (Cached ArrayIndex)
+
+-- | Read the array element at @a@
+readSArr :: SArr -> SVal -> SVal
+readSArr (SArr (_, bk) f) a = SVal bk $ Right $ cache r
+  where r st = do arr <- uncacheAI f st
+                  i   <- svToSW st a
+                  newExpr st bk (SBVApp (ArrRead arr) [i])
+
+-- | Reset all the elements of the array to the value @b@
+resetSArr :: SArr -> SVal -> SArr
+resetSArr (SArr ainfo f) b = SArr ainfo $ cache g
+  where g st = do amap <- readIORef (rArrayMap st)
+                  val <- svToSW st b
+                  i <- uncacheAI f st
+                  let j = IMap.size amap
+                  j `seq` modifyIORef (rArrayMap st) (IMap.insert j ("array_" ++ show j, ainfo, ArrayReset i val))
+                  return j
+
+-- | Update the element at @a@ to be @b@
+writeSArr :: SArr -> SVal -> SVal -> SArr
+writeSArr (SArr ainfo f) a b = SArr ainfo $ cache g
+  where g st = do arr  <- uncacheAI f st
+                  addr <- svToSW st a
+                  val  <- svToSW st b
+                  amap <- readIORef (rArrayMap st)
+                  let j = IMap.size amap
+                  j `seq` modifyIORef (rArrayMap st) (IMap.insert j ("array_" ++ show j, ainfo, ArrayMutate arr addr val))
+                  return j
+
+-- | Merge two given arrays on the symbolic condition
+-- Intuitively: @mergeArrays cond a b = if cond then a else b@.
+-- Merging pushes the if-then-else choice down on to elements
+mergeSArr :: SVal -> SArr -> SArr -> SArr
+mergeSArr t (SArr ainfo a) (SArr _ b) = SArr ainfo $ cache h
+  where h st = do ai <- uncacheAI a st
+                  bi <- uncacheAI b st
+                  ts <- svToSW st t
+                  amap <- readIORef (rArrayMap st)
+                  let k = IMap.size amap
+                  k `seq` modifyIORef (rArrayMap st) (IMap.insert k ("array_" ++ show k, ainfo, ArrayMerge ts ai bi))
+                  return k
+
+-- | Create a named new array, with an optional initial value
+newSArr :: (Kind, Kind) -> (Int -> String) -> Maybe SVal -> Symbolic SArr
+newSArr ainfo mkNm mbInit = do
+    st <- ask
+    amap <- liftIO $ readIORef $ rArrayMap st
+    let i = IMap.size amap
+        nm = mkNm i
+    actx <- liftIO $ case mbInit of
+                       Nothing   -> return $ ArrayFree Nothing
+                       Just ival -> svToSW st ival >>= \sw -> return $ ArrayFree (Just sw)
+    liftIO $ modifyIORef (rArrayMap st) (IMap.insert i (nm, ainfo, actx))
+    return $ SArr ainfo $ cache $ const $ return i
+
+-- | Compare two arrays for equality
+eqSArr :: SArr -> SArr -> SVal
+eqSArr (SArr _ a) (SArr _ b) = SVal KBool $ Right $ cache c
+  where c st = do ai <- uncacheAI a st
+                  bi <- uncacheAI b st
+                  newExpr st KBool (SBVApp (ArrEq ai bi) [])
+
+---------------------------------------------------------------------------------
+-- * Cached values
+---------------------------------------------------------------------------------
+
+-- | We implement a peculiar caching mechanism, applicable to the use case in
+-- implementation of SBV's.  Whenever we do a state based computation, we do
+-- not want to keep on evaluating it in the then-current state. That will
+-- produce essentially a semantically equivalent value. Thus, we want to run
+-- it only once, and reuse that result, capturing the sharing at the Haskell
+-- level. This is similar to the "type-safe observable sharing" work, but also
+-- takes into the account of how symbolic simulation executes.
+--
+-- See Andy Gill's type-safe obervable sharing trick for the inspiration behind
+-- this technique: <http://ittc.ku.edu/~andygill/paper.php?label=DSLExtract09>
+--
+-- Note that this is *not* a general memo utility!
+newtype Cached a = Cached (State -> IO a)
+
+-- | Cache a state-based computation
+cache :: (State -> IO a) -> Cached a
+cache = Cached
+
+-- | Uncache a previously cached computation
+uncache :: Cached SW -> State -> IO SW
+uncache = uncacheGen rSWCache
+
+-- | An array index is simple an int value
+type ArrayIndex = Int
+
+-- | Uncache, retrieving array indexes
+uncacheAI :: Cached ArrayIndex -> State -> IO ArrayIndex
+uncacheAI = uncacheGen rAICache
+
+-- | Generic uncaching. Note that this is entirely safe, since we do it in the IO monad.
+uncacheGen :: (State -> IORef (Cache a)) -> Cached a -> State -> IO a
+uncacheGen getCache (Cached f) st = do
+        let rCache = getCache st
+        stored <- readIORef rCache
+        sn <- f `seq` makeStableName f
+        let h = hashStableName sn
+        case maybe Nothing (sn `lookup`) (h `IMap.lookup` stored) of
+          Just r  -> return r
+          Nothing -> do r <- f st
+                        r `seq` modifyIORef rCache (IMap.insertWith (++) h [(sn, r)])
+                        return r
+
+-- | Representation of SMTLib Program versions, currently we only know of versions 1 and 2.
+-- (NB. Eventually, we should just drop SMTLib1.)
+data SMTLibVersion = SMTLib1
+                   | SMTLib2
+                   deriving Eq
+
+-- | Representation of an SMT-Lib program. In between pre and post goes the refuted models
+data SMTLibPgm = SMTLibPgm SMTLibVersion  ( [(String, SW)]          -- alias table
+                                          , [String]                -- pre: declarations.
+                                          , [String])               -- post: formula
+instance NFData SMTLibVersion where rnf a = seq a ()
+instance NFData SMTLibPgm     where rnf a = seq a ()
+
+instance Show SMTLibPgm where
+  show (SMTLibPgm _ (_, pre, post)) = intercalate "\n" $ pre ++ post
+
+-- Other Technicalities..
+instance NFData CW where
+  rnf (CW x y) = x `seq` y `seq` ()
+
+instance NFData Result where
+  rnf (Result kindInfo qcInfo cgs inps consts tbls arrs uis axs pgm cstr outs)
+        = rnf kindInfo `seq` rnf qcInfo `seq` rnf cgs  `seq` rnf inps
+                       `seq` rnf consts `seq` rnf tbls `seq` rnf arrs
+                       `seq` rnf uis    `seq` rnf axs  `seq` rnf pgm
+                       `seq` rnf cstr   `seq` rnf outs
+instance NFData Kind          where rnf a = seq a ()
+instance NFData ArrayContext  where rnf a = seq a ()
+instance NFData SW            where rnf a = seq a ()
+instance NFData SBVExpr       where rnf a = seq a ()
+instance NFData Quantifier    where rnf a = seq a ()
+instance NFData SBVType       where rnf a = seq a ()
+instance NFData UnintKind     where rnf a = seq a ()
+instance NFData a => NFData (Cached a) where
+  rnf (Cached f) = f `seq` ()
+instance NFData SVal where
+  rnf (SVal x y) = rnf x `seq` rnf y `seq` ()
+instance NFData SBVPgm        where rnf a = seq a ()
+
+
+instance NFData SMTResult where
+  rnf (Unsatisfiable _)   = ()
+  rnf (Satisfiable _ xs)  = rnf xs `seq` ()
+  rnf (Unknown _ xs)      = rnf xs `seq` ()
+  rnf (ProofError _ xs)   = rnf xs `seq` ()
+  rnf (TimeOut _)         = ()
+
+instance NFData SMTModel where
+  rnf (SMTModel assocs unints uarrs) = rnf assocs `seq` rnf unints `seq` rnf uarrs `seq` ()
+
+instance NFData SMTScript where
+  rnf (SMTScript b m) = rnf b `seq` rnf m `seq` ()
+
+-- | SMT-Lib logics. If left unspecified SBV will pick the logic based on what it determines is needed. However, the
+-- user can override this choice using the 'useLogic' parameter to the configuration. This is especially handy if
+-- one is experimenting with custom logics that might be supported on new solvers. See <http://smtlib.cs.uiowa.edu/logics.shtml>
+-- for the official list.
+data SMTLibLogic
+  = AUFLIA    -- ^ Formulas over the theory of linear integer arithmetic and arrays extended with free sort and function symbols but restricted to arrays with integer indices and values
+  | AUFLIRA   -- ^ Linear formulas with free sort and function symbols over one- and two-dimentional arrays of integer index and real value
+  | AUFNIRA   -- ^ Formulas with free function and predicate symbols over a theory of arrays of arrays of integer index and real value
+  | LRA       -- ^ Linear formulas in linear real arithmetic
+  | QF_ABV    -- ^ Quantifier-free formulas over the theory of bitvectors and bitvector arrays
+  | QF_AUFBV  -- ^ Quantifier-free formulas over the theory of bitvectors and bitvector arrays extended with free sort and function symbols
+  | QF_AUFLIA -- ^ Quantifier-free linear formulas over the theory of integer arrays extended with free sort and function symbols
+  | QF_AX     -- ^ Quantifier-free formulas over the theory of arrays with extensionality
+  | QF_BV     -- ^ Quantifier-free formulas over the theory of fixed-size bitvectors
+  | QF_IDL    -- ^ Difference Logic over the integers. Boolean combinations of inequations of the form x - y < b where x and y are integer variables and b is an integer constant
+  | QF_LIA    -- ^ Unquantified linear integer arithmetic. In essence, Boolean combinations of inequations between linear polynomials over integer variables
+  | QF_LRA    -- ^ Unquantified linear real arithmetic. In essence, Boolean combinations of inequations between linear polynomials over real variables.
+  | QF_NIA    -- ^ Quantifier-free integer arithmetic.
+  | QF_NRA    -- ^ Quantifier-free real arithmetic.
+  | QF_RDL    -- ^ Difference Logic over the reals. In essence, Boolean combinations of inequations of the form x - y < b where x and y are real variables and b is a rational constant.
+  | QF_UF     -- ^ Unquantified formulas built over a signature of uninterpreted (i.e., free) sort and function symbols.
+  | QF_UFBV   -- ^ Unquantified formulas over bitvectors with uninterpreted sort function and symbols.
+  | QF_UFIDL  -- ^ Difference Logic over the integers (in essence) but with uninterpreted sort and function symbols.
+  | QF_UFLIA  -- ^ Unquantified linear integer arithmetic with uninterpreted sort and function symbols.
+  | QF_UFLRA  -- ^ Unquantified linear real arithmetic with uninterpreted sort and function symbols.
+  | QF_UFNRA  -- ^ Unquantified non-linear real arithmetic with uninterpreted sort and function symbols.
+  | UFLRA     -- ^ Linear real arithmetic with uninterpreted sort and function symbols.
+  | UFNIA     -- ^ Non-linear integer arithmetic with uninterpreted sort and function symbols.
+  | QF_FPBV   -- ^ Quantifier-free formulas over the theory of floating point numbers, arrays, and bit-vectors
+  | QF_FP     -- ^ Quantifier-free formulas over the theory of floating point numbers
+  deriving Show
+
+-- | Chosen logic for the solver
+data Logic = PredefinedLogic SMTLibLogic  -- ^ Use one of the logics as defined by the standard
+           | CustomLogic     String       -- ^ Use this name for the logic
+
+instance Show Logic where
+  show (PredefinedLogic l) = show l
+  show (CustomLogic     s) = s
+
+-- | Translation tricks needed for specific capabilities afforded by each solver
+data SolverCapabilities = SolverCapabilities {
+         capSolverName              :: String       -- ^ Name of the solver
+       , mbDefaultLogic             :: Maybe String -- ^ set-logic string to use in case not automatically determined (if any)
+       , supportsMacros             :: Bool         -- ^ Does the solver understand SMT-Lib2 macros?
+       , supportsProduceModels      :: Bool         -- ^ Does the solver understand produce-models option setting
+       , supportsQuantifiers        :: Bool         -- ^ Does the solver understand SMT-Lib2 style quantifiers?
+       , supportsUninterpretedSorts :: Bool         -- ^ Does the solver understand SMT-Lib2 style uninterpreted-sorts
+       , supportsUnboundedInts      :: Bool         -- ^ Does the solver support unbounded integers?
+       , supportsReals              :: Bool         -- ^ Does the solver support reals?
+       , supportsFloats             :: Bool         -- ^ Does the solver support single-precision floating point numbers?
+       , supportsDoubles            :: Bool         -- ^ Does the solver support double-precision floating point numbers?
+       }
+
+-- | Rounding mode to be used for the IEEE floating-point operations.
+-- Note that Haskell's default is 'RoundNearestTiesToEven'. If you use
+-- a different rounding mode, then the counter-examples you get may not
+-- match what you observe in Haskell.
+data RoundingMode = RoundNearestTiesToEven  -- ^ Round to nearest representable floating point value.
+                                            -- If precisely at half-way, pick the even number.
+                                            -- (In this context, /even/ means the lowest-order bit is zero.)
+                  | RoundNearestTiesToAway  -- ^ Round to nearest representable floating point value.
+                                            -- If precisely at half-way, pick the number further away from 0.
+                                            -- (That is, for positive values, pick the greater; for negative values, pick the smaller.)
+                  | RoundTowardPositive     -- ^ Round towards positive infinity. (Also known as rounding-up or ceiling.)
+                  | RoundTowardNegative     -- ^ Round towards negative infinity. (Also known as rounding-down or floor.)
+                  | RoundTowardZero         -- ^ Round towards zero. (Also known as truncation.)
+                  deriving (Eq, Ord, G.Data, T.Typeable, Read, Show, Bounded, Enum)
+
+-- | Solver configuration. See also 'z3', 'yices', 'cvc4', 'boolector', 'mathSAT', etc. which are instantiations of this type for those solvers, with
+-- reasonable defaults. In particular, custom configuration can be created by varying those values. (Such as @z3{verbose=True}@.)
+--
+-- Most fields are self explanatory. The notion of precision for printing algebraic reals stems from the fact that such values does
+-- not necessarily have finite decimal representations, and hence we have to stop printing at some depth. It is important to
+-- emphasize that such values always have infinite precision internally. The issue is merely with how we print such an infinite
+-- precision value on the screen. The field 'printRealPrec' controls the printing precision, by specifying the number of digits after
+-- the decimal point. The default value is 16, but it can be set to any positive integer.
+--
+-- When printing, SBV will add the suffix @...@ at the and of a real-value, if the given bound is not sufficient to represent the real-value
+-- exactly. Otherwise, the number will be written out in standard decimal notation. Note that SBV will always print the whole value if it
+-- is precise (i.e., if it fits in a finite number of digits), regardless of the precision limit. The limit only applies if the representation
+-- of the real value is not finite, i.e., if it is not rational.
+data SMTConfig = SMTConfig {
+         verbose        :: Bool             -- ^ Debug mode
+       , timing         :: Bool             -- ^ Print timing information on how long different phases took (construction, solving, etc.)
+       , sBranchTimeOut :: Maybe Int        -- ^ How much time to give to the solver for each call of 'sBranch' check. (In seconds. Default: No limit.)
+       , timeOut        :: Maybe Int        -- ^ How much time to give to the solver. (In seconds. Default: No limit.)
+       , printBase      :: Int              -- ^ Print integral literals in this base (2, 8, 10, and 16 are supported.)
+       , printRealPrec  :: Int              -- ^ Print algebraic real values with this precision. (SReal, default: 16)
+       , solverTweaks   :: [String]         -- ^ Additional lines of script to give to the solver (user specified)
+       , satCmd         :: String           -- ^ Usually "(check-sat)". However, users might tweak it based on solver characteristics.
+       , smtFile        :: Maybe FilePath   -- ^ If Just, the generated SMT script will be put in this file (for debugging purposes mostly)
+       , useSMTLib2     :: Bool             -- ^ If True, we'll treat the solver as using SMTLib2 input format. Otherwise, SMTLib1
+       , solver         :: SMTSolver        -- ^ The actual SMT solver.
+       , roundingMode   :: RoundingMode     -- ^ Rounding mode to use for floating-point conversions
+       , useLogic       :: Maybe Logic      -- ^ If Nothing, pick automatically. Otherwise, either use the given one, or use the custom string.
+       }
+
+instance Show SMTConfig where
+  show = show . solver
+
+-- | A model, as returned by a solver
+data SMTModel = SMTModel {
+        modelAssocs    :: [(String, CW)]        -- ^ Mapping of symbolic values to constants.
+     ,  modelArrays    :: [(String, [String])]  -- ^ Arrays, very crude; only works with Yices.
+     ,  modelUninterps :: [(String, [String])]  -- ^ Uninterpreted funcs; very crude; only works with Yices.
+     }
+     deriving Show
+
+-- | The result of an SMT solver call. Each constructor is tagged with
+-- the 'SMTConfig' that created it so that further tools can inspect it
+-- and build layers of results, if needed. For ordinary uses of the library,
+-- this type should not be needed, instead use the accessor functions on
+-- it. (Custom Show instances and model extractors.)
+data SMTResult = Unsatisfiable SMTConfig            -- ^ Unsatisfiable
+               | Satisfiable   SMTConfig SMTModel   -- ^ Satisfiable with model
+               | Unknown       SMTConfig SMTModel   -- ^ Prover returned unknown, with a potential (possibly bogus) model
+               | ProofError    SMTConfig [String]   -- ^ Prover errored out
+               | TimeOut       SMTConfig            -- ^ Computation timed out (see the 'timeout' combinator)
+
+-- | A script, to be passed to the solver.
+data SMTScript = SMTScript {
+          scriptBody  :: String        -- ^ Initial feed
+        , scriptModel :: Maybe String  -- ^ Optional continuation script, if the result is sat
+        }
+
+-- | An SMT engine
+type SMTEngine = SMTConfig -> Bool -> [(Quantifier, NamedSymVar)] -> [(String, UnintKind)] -> [Either SW (SW, [SW])] -> String -> IO SMTResult
+
+-- | Solvers that SBV is aware of
+data Solver = Z3
+            | Yices
+            | Boolector
+            | CVC4
+            | MathSAT
+            | ABC
+            deriving (Show, Enum, Bounded)
+
+-- | An SMT solver
+data SMTSolver = SMTSolver {
+         name           :: Solver               -- ^ The solver in use
+       , executable     :: String               -- ^ The path to its executable
+       , options        :: [String]             -- ^ Options to provide to the solver
+       , engine         :: SMTEngine            -- ^ The solver engine, responsible for interpreting solver output
+       , xformExitCode  :: ExitCode -> ExitCode -- ^ Should we re-interpret exit codes. Most solvers behave rationally, i.e., id will do. Some (like CVC4) don't.
+       , capabilities   :: SolverCapabilities   -- ^ Various capabilities of the solver
+       }
+
+instance Show SMTSolver where
+   show = show . name

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -30,6 +30,7 @@ module Data.SBV.BitVectors.Symbolic
   , RoundingMode(..)
   , SBVType(..), newUninterpreted, unintFnUIKind, addAxiom
   , SVal(..), svKind
+  , svBitSize, svSigned
   , svMkSymVar
   , ArrayContext(..), ArrayInfo, arrayUIKind
   , svToSW, forceSWArg
@@ -403,6 +404,15 @@ data SVal = SVal !Kind !(Either CW (Cached SW))
 
 svKind :: SVal -> Kind
 svKind (SVal k _) = k
+
+svBitSize :: SVal -> Int
+svBitSize x =
+  case svKind x of
+    KBounded _ s  -> s
+    _             -> error $ "svBitSize: invalid kind " ++ show (svKind x)
+
+svSigned :: SVal -> Bool
+svSigned x = kindHasSign (svKind x)
 
 -- Not particularly "desirable", but will do if needed
 instance Show SVal where

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -26,7 +26,7 @@ module Data.SBV.Dynamic
   , svAsBool
   -- ** Basic operations
   , svPlus, svTimes, svMinus, svUNeg, svAbs
-  , svQuot, svRem
+  , svDivide, svQuot, svRem
   , svEqual, svNotEqual
   , svLessThan, svGreaterThan, svLessEq, svGreaterEq
   , svAnd, svOr, svXOr, svNot

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -1,0 +1,40 @@
+---------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.Dynamic
+-- Copyright   :  (c) Levent Erkok
+-- License     :  BSD3
+-- Maintainer  :  erkokl@gmail.com
+-- Stability   :  experimental
+--
+-- Dynamically typed low-level API to the SBV library, for users who
+-- want to generate symbolic values at run-time. Note that with this
+-- API it is possible to create terms that are not type correct; use
+-- at your own risk!
+---------------------------------------------------------------------------------
+
+module Data.SBV.Dynamic
+  ( Kind(..)
+  , Symbolic
+  , Quantifier(..)
+  , SVal
+  , svKind
+  , svMkSymVar
+  -- ** Basic constructors
+  , svTrue, svFalse, svBool
+  , svInteger
+  , svAsBool
+  -- ** Basic operations
+  , svPlus, svTimes, svMinus, svUNeg, svAbs
+  , svQuot, svRem
+  , svEqual, svNotEqual
+  , svLessThan, svGreaterThan, svLessEq, svGreaterEq
+  , svAnd, svOr, svXOr, svNot
+  , svShl, svShr, svRol, svRor
+  , svExtract, svJoin
+  , svUninterpreted
+  , svIte, svLazyIte, svSymbolicMerge
+  ) where
+
+import Data.SBV.BitVectors.Kind
+import Data.SBV.BitVectors.Symbolic
+import Data.SBV.BitVectors.Operations

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -34,6 +34,11 @@ module Data.SBV.Dynamic
   , svExtract, svJoin
   , svUninterpreted
   , svIte, svLazyIte, svSymbolicMerge
+  , svSelect
+  -- ** Derived operations
+  , svToWord1, svFromWord1, svTestBit
+  , svShiftLeft, svShiftRight
+  , svRotateLeft, svRotateRight
   ) where
 
 import Data.SBV.BitVectors.Kind

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -18,6 +18,7 @@ module Data.SBV.Dynamic
   , Quantifier(..)
   , SVal
   , svKind
+  , svBitSize, svSigned
   , svMkSymVar
   -- ** Basic constructors
   , svTrue, svFalse, svBool

--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -17,7 +17,7 @@ module Data.SBV.Internals (
   -- * Other internal structures useful for low-level programming
   , SBV(..), slet, CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW, genVar, genVar_
   , liftQRem, liftDMod, symbolicMergeWithKind
-  , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom
+  , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..)
   , SBVType(..), newUninterpreted, forceSWArg
   -- * Operations useful for instantiating SBV type classes
   , genLiteral, genFromCW, genMkSymVar, checkAndConvert, genParse
@@ -28,7 +28,7 @@ module Data.SBV.Internals (
   ) where
 
 import Data.SBV.BitVectors.Data       (Result, SBVRunMode(..), runSymbolic, runSymbolic', SBV(..), CW(..), Kind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW)
-import Data.SBV.BitVectors.Data       (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), mkSymSBVWithRandom, SBVType(..), newUninterpreted, forceSWArg)
+import Data.SBV.BitVectors.Data       (cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), SBVType(..), newUninterpreted, forceSWArg)
 import Data.SBV.BitVectors.Model      (genVar, genVar_, slet, liftQRem, liftDMod, symbolicMergeWithKind, genLiteral, genFromCW, genMkSymVar)
 import Data.SBV.BitVectors.Splittable (checkAndConvert)
 import Data.SBV.Compilers.C           (compileToC', compileToCLib')

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -92,7 +92,9 @@ Library
                   , Data.SBV.Examples.Uninterpreted.Sort
                   , Data.SBV.Examples.Uninterpreted.UISortAllSat
   Other-modules   : Data.SBV.BitVectors.AlgReals
+                  , Data.SBV.BitVectors.Concrete
                   , Data.SBV.BitVectors.Data
+                  , Data.SBV.BitVectors.Kind
                   , Data.SBV.BitVectors.Model
                   , Data.SBV.BitVectors.PrettyNum
                   , Data.SBV.BitVectors.Rounding

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -101,6 +101,7 @@ Library
                   , Data.SBV.BitVectors.SignCast
                   , Data.SBV.BitVectors.Splittable
                   , Data.SBV.BitVectors.STree
+                  , Data.SBV.BitVectors.Symbolic
                   , Data.SBV.Compilers.C
                   , Data.SBV.Compilers.CodeGen
                   , Data.SBV.SMT.SMT

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -96,6 +96,7 @@ Library
                   , Data.SBV.BitVectors.Data
                   , Data.SBV.BitVectors.Kind
                   , Data.SBV.BitVectors.Model
+                  , Data.SBV.BitVectors.Operations
                   , Data.SBV.BitVectors.PrettyNum
                   , Data.SBV.BitVectors.Rounding
                   , Data.SBV.BitVectors.SignCast

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -56,6 +56,7 @@ Library
                   , Data.SBV.Bridge.Yices
                   , Data.SBV.Bridge.Z3
                   , Data.SBV.Bridge.ABC
+                  , Data.SBV.Dynamic
                   , Data.SBV.Internals
                   , Data.SBV.Examples.BitPrecise.BitTricks
                   , Data.SBV.Examples.BitPrecise.Legato


### PR DESCRIPTION
This has reached the point where Data.SBV.Dynamic is actually useful. I have prepared a modified version of Cryptol that works with it, where I was able to remove about 100 lines of boilerplate and dummy instance declarations.

The Dynamic API is still somewhat incomplete; the modified Cryptol adds and removes newtype wrappers in several places to let it use stuff from the ordinary Data.SBV interface. Eventually I'd like for Cryptol to get everything it needs by importing *only* Data.SBV.Dynamic, but anyway I think this is a good start.