### PR TITLE
Dynamic

### DIFF
--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -661,8 +661,7 @@ instance (Num a, Bits a, SymWord a) => Bits (SBV a) where
 -- | Replacement for 'testBit'. Since 'testBit' requires a 'Bool' to be returned,
 -- we cannot implement it for symbolic words. Index 0 is the least-significant bit.
 sbvTestBit :: (Num a, Bits a, SymWord a) => SBV a -> Int -> SBool
-sbvTestBit x i = (x .&. genLiteral k (bit i :: Integer)) ./= genLiteral k (0::Integer)
-  where k = kindOf x
+sbvTestBit (SBV x) i = SBV (svTestBit x i)
 
 -- | Replacement for 'popCount'. Since 'popCount' returns an 'Int', we cannot implement
 -- it for symbolic words. Here, we return an 'SWord8', which can overflow when used on

--- a/Data/SBV/BitVectors/Operations.hs
+++ b/Data/SBV/BitVectors/Operations.hs
@@ -465,7 +465,9 @@ svFromWord1 x = svEqual x (svInteger k 1)
 -- as opposed to masking and checking against zero, as we found
 -- extraction to be much faster with large bit-vectors.
 svTestBit :: SVal -> Int -> SVal
-svTestBit x i = svFromWord1 (svExtract i i x)
+svTestBit x i
+  | i < svBitSize x = svFromWord1 (svExtract i i x)
+  | True            = svFalse
 
 -- | Generalization of 'svShl', where the shift-amount is symbolic.
 -- The shift amount must be an unsigned quantity.


### PR DESCRIPTION
Running `cabal test`, it looks like this change causes some `arithCF` tests to fail (specifically, the ones that involve `fromBitsLE`/`blastLE` and friends). I suppose these regression tests check that the generated SMTLib stays exactly the same, is that right? In that case, we will need to regenerate the expected test case output, since the new sbvTestBit generates different SMTLib operations.