### PR TITLE
add compatibility shims for 7.8

### DIFF
--- a/Data/SBV/BitVectors/Model.hs
+++ b/Data/SBV/BitVectors/Model.hs
@@ -40,7 +40,7 @@ import Control.Monad        (when, liftM)
 import Control.Monad.Reader (ask)
 import Control.Monad.Trans  (liftIO)
 
-import GHC.Stack
+import GHC.Stack.Compat
 
 import Data.Array      (Array, Ix, listArray, elems, bounds, rangeSize)
 import Data.Bits       (Bits(..))

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -61,7 +61,7 @@ import Data.IORef           (IORef, newIORef, modifyIORef, readIORef, writeIORef
 import Data.List            (intercalate, sortBy)
 import Data.Maybe           (isJust, fromJust, fromMaybe)
 
-import GHC.Stack
+import GHC.Stack.Compat
 
 import qualified Data.Generics as G    (Data(..))
 import qualified Data.Typeable as T    (Typeable)

--- a/Data/SBV/Compilers/C.hs
+++ b/Data/SBV/Compilers/C.hs
@@ -27,8 +27,8 @@ import Data.SBV.BitVectors.Data
 import Data.SBV.BitVectors.PrettyNum (shex, showCFloat, showCDouble)
 import Data.SBV.Compilers.CodeGen
 
-import GHC.Stack
-import GHC.SrcLoc
+import GHC.Stack.Compat
+import GHC.SrcLoc.Compat
 
 ---------------------------------------------------------------------------
 -- * API

--- a/Data/SBV/Provers/Prover.hs
+++ b/Data/SBV/Provers/Prover.hs
@@ -37,8 +37,8 @@ import System.FilePath  (addExtension, splitExtension)
 import System.Time      (getClockTime)
 import System.IO.Unsafe (unsafeInterleaveIO)
 
-import GHC.Stack
-import GHC.SrcLoc
+import GHC.Stack.Compat
+import GHC.SrcLoc.Compat
 
 import qualified Data.Set as Set (Set, toList)
 

--- a/GHC/SrcLoc/Compat.hs
+++ b/GHC/SrcLoc/Compat.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility shim for GHC 7.8 support. Remove once 7.8 is no
+-- longer supported.
+
+#if MIN_VERSION_base(4,8,0)
+
+module GHC.SrcLoc.Compat (module GHC.SrcLoc) where
+import GHC.SrcLoc
+
+#else
+
+module GHC.SrcLoc.Compat {-# WARNING "This version of GHC does not support SrcLoc; using a stub interface for compatibility" #-} (module GHC.SrcLoc.Compat) where
+
+data SrcLoc
+
+srcLocFile :: SrcLoc -> String
+srcLocFile _ = ""
+
+srcLocStartLine :: SrcLoc -> Int
+srcLocStartLine _ = 0
+
+srcLocStartCol :: SrcLoc -> Int
+srcLocStartCol _ = 0
+
+#endif

--- a/GHC/Stack/Compat.hs
+++ b/GHC/Stack/Compat.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility shim for GHC 7.8 support. Remove once 7.8 is no
+-- longer supported.
+
+#if MIN_VERSION_base(4,8,0)
+
+module GHC.Stack.Compat (module GHC.Stack) where
+import GHC.Stack
+
+#else
+
+module GHC.Stack.Compat {-# WARNING "This version of GHC does not support SrcLoc; using a stub interface for compatibility" #-} (module GHC.Stack.Compat) where
+
+import GHC.SrcLoc.Compat
+
+data CallStack
+
+getCallStack :: CallStack -> [(String, SrcLoc)]
+getCallStack _ = []
+
+showCallStack :: CallStack -> String
+showCallStack _ = "CallStack not supported in GHC older than 7.10"
+
+#endif

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -131,6 +131,8 @@ Library
                   , Data.SBV.Utils.Numeric
                   , Data.SBV.Utils.TDiff
                   , Data.SBV.Utils.Lib
+                  , GHC.SrcLoc.Compat
+                  , GHC.Stack.Compat
 
 Executable SBVUnitTests
   default-language: Haskell2010


### PR DESCRIPTION
This tries to be minimally invasive by adding `Compat` modules for the
relevant bits. Of course, unlike a true compat module this doesn't
reimplement the functionality lost in earlier versions, instead I have
it set to emit warnings and return benign values like empty strings and
`0`.

When the next GHC is out, we can drop 7.8 and tear all this stuff back
out :+1: