### PR TITLE
Export `HasKind(..)` from Dynamic interface

### DIFF
--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -18,7 +18,7 @@ module Data.SBV.Dynamic
   -- ** Symbolic types
   -- *** Abstract symbolic value type
     SVal
-  , Kind(..), CW(..), CWVal(..), cwToBool
+  , HasKind(..), Kind(..), CW(..), CWVal(..), cwToBool
   -- *** Arrays of symbolic values
   , SArr
   , readSArr, resetSArr, writeSArr, mergeSArr, newSArr, eqSArr


### PR DESCRIPTION
This must have been implicitly exported before somehow, but now needs to be explicit