### PR TITLE
Implement automatic Mergeable instances with GHC.Generics.

### DIFF
--- a/Data/SBV/Examples/BitPrecise/Legato.hs
+++ b/Data/SBV/Examples/BitPrecise/Legato.hs
@@ -31,11 +31,16 @@
 -- is indeed correct.
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+
 module Data.SBV.Examples.BitPrecise.Legato where
 
 import Data.Array (Array, Ix(..), (!), (//), array)
 
 import Data.SBV
+
+import GHC.Generics (Generic)
 
 ------------------------------------------------------------------
 -- * Mostek architecture
@@ -71,7 +76,7 @@ type Memory = Model Word32 Word8        -- Model defined later
 data Mostek = Mostek { memory    :: Memory
                      , registers :: Registers
                      , flags     :: Flags
-                     }
+                     } deriving (Generic, Mergeable)
 
 -- | Given a machine state, compute a value out of it
 type Extract a = Mostek -> a
@@ -80,11 +85,11 @@ type Extract a = Mostek -> a
 type Program = Mostek -> Mostek
 
 -- | 'Mergeable' instance of 'Mostek' simply pushes the merging into record fields.
-instance Mergeable Mostek where
-  symbolicMerge f b m1 m2 = Mostek { memory    = symbolicMerge f b (memory m1)    (memory m2)
-                                   , registers = symbolicMerge f b (registers m1) (registers m2)
-                                   , flags     = symbolicMerge f b (flags m1)     (flags m2)
-                                   }
+-- instance Mergeable Mostek where
+--   symbolicMerge f b m1 m2 = Mostek { memory    = symbolicMerge f b (memory m1)    (memory m2)
+--                                    , registers = symbolicMerge f b (registers m1) (registers m2)
+--                                    , flags     = symbolicMerge f b (flags m1)     (flags m2)
+--                                    }
 
 ------------------------------------------------------------------
 -- * Low-level operations

--- a/Data/SBV/Examples/Puzzles/U2Bridge.hs
+++ b/Data/SBV/Examples/Puzzles/U2Bridge.hs
@@ -11,6 +11,7 @@
 
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
@@ -19,8 +20,11 @@ module Data.SBV.Examples.Puzzles.U2Bridge where
 import Control.Monad       (unless)
 import Control.Monad.State (State, runState, put, get, modify, evalState)
 
-import Data.Generics
+import Data.Generics (Data)
+import GHC.Generics (Generic)
+
 import Data.SBV
+
 
 -------------------------------------------------------------
 -- * Modeling the puzzle
@@ -74,7 +78,7 @@ data Status = Status { time   :: STime       -- ^ elapsed time
                      , lEdge  :: SLocation   -- ^ location of Edge
                      , lAdam  :: SLocation   -- ^ location of Adam
                      , lLarry :: SLocation   -- ^ location of Larry
-                     }
+                     } deriving (Generic, Mergeable)
 
 -- | Start configuration, time elapsed is 0 and everybody is 'here'
 start :: Status
@@ -88,14 +92,14 @@ start = Status { time   = 0
 
 -- | Mergeable instance for 'Status' simply walks down the structure fields and
 -- merges them.
-instance Mergeable Status where
-  symbolicMerge f t s1 s2 = Status { time   = symbolicMerge f t (time   s1) (time   s2)
-                                   , flash  = symbolicMerge f t (flash  s1) (flash  s2)
-                                   , lBono  = symbolicMerge f t (lBono  s1) (lBono  s2)
-                                   , lEdge  = symbolicMerge f t (lEdge  s1) (lEdge  s2)
-                                   , lAdam  = symbolicMerge f t (lAdam  s1) (lAdam  s2)
-                                   , lLarry = symbolicMerge f t (lLarry s1) (lLarry s2)
-                                   }
+-- instance Mergeable Status where
+--   symbolicMerge f t s1 s2 = Status { time   = symbolicMerge f t (time   s1) (time   s2)
+--                                    , flash  = symbolicMerge f t (flash  s1) (flash  s2)
+--                                    , lBono  = symbolicMerge f t (lBono  s1) (lBono  s2)
+--                                    , lEdge  = symbolicMerge f t (lEdge  s1) (lEdge  s2)
+--                                    , lAdam  = symbolicMerge f t (lAdam  s1) (lAdam  s2)
+--                                    , lLarry = symbolicMerge f t (lLarry s1) (lLarry s2)
+--                                    }
 
 -- | A puzzle move is modeled as a state-transformer
 type Move a = State Status a


### PR DESCRIPTION
Using GHC.Generics, we can automatically derive the trivial `Mergeable` instances for product types like `Status` in the U2 example and `Mostek` in the Legato example.

This is more of a proposal than a pull request. Because of the design of GHC.Generics, this convenience feature must be implemented in `sbv` itself. If there's interest I can write documentation, conform to the project coding style if I haven't, etc. 

This implementation should be sound. I can't really opine on its performance impact. Generics represents products recursively, so the derived instance of, say, `data T a = T a a a` will be similar to to that for `(a, (a, a))`, *not* to the flat 3-tuple `(a, a, a)`. I don't know whether this will make a difference in practice.

Perhaps more significantly, this approach also can't implement `select` the way the existing tuple implementation does, i.e. by using the `select` implementation for the underlying types. This limitation arises because there can't be two default implementations for `select`. Therefore the derived instance does not benefit from the optimized `select` in the `SBV a` instance. But of course this limitation also applies to the existing boilerplate implementations in the examples, which don't include the boilerplate for `select`.

One possible solution to the `select` issue would be to export a `selectDefault` similar to the existing `symbolicMergeDefault`; the consumer could then write the instance explicitly: `instance Mergeable MyType where { select = selectDefault }`. This might be confusing, and loses the benefit of `DeriveAnyType`.