### PR TITLE
Document Mergeable deriving. Un-break Haddock for 'select'.

### DIFF
--- a/Data/SBV/Examples/BitPrecise/Legato.hs
+++ b/Data/SBV/Examples/BitPrecise/Legato.hs
@@ -73,6 +73,9 @@ type Memory = Model Word32 Word8        -- Model defined later
 -- | Abstraction of the machine: The CPU consists of memory, registers, and flags.
 -- Unlike traditional hardware, we assume the program is stored in some other memory area that
 -- we need not model. (No self modifying programs!)
+--
+-- 'Mostek' is equipped with an automatically derived 'Mergeable' instance
+-- because each field is 'Mergeable'.
 data Mostek = Mostek { memory    :: Memory
                      , registers :: Registers
                      , flags     :: Flags

--- a/Data/SBV/Examples/Puzzles/U2Bridge.hs
+++ b/Data/SBV/Examples/Puzzles/U2Bridge.hs
@@ -71,6 +71,13 @@ here, there :: SLocation
 [here, there]  = map literal [Here, There]
 
 -- | The status of the puzzle after each move
+--
+-- This type is equipped with an automatically derived 'Mergeable' instance
+-- because each field is 'Mergeable'. A 'Generic' instance must also be derived
+-- for this to work, and the 'DeriveAnyClass' language extension must be
+-- enabled. The derived 'Mergeable' instance simply walks down the structure
+-- field by field and merges each one. An equivalent hand-written 'Mergeable'
+-- instance is provided in a comment below.
 data Status = Status { time   :: STime       -- ^ elapsed time
                      , flash  :: SLocation   -- ^ location of the flash
                      , lBono  :: SLocation   -- ^ location of Bono
@@ -78,6 +85,17 @@ data Status = Status { time   :: STime       -- ^ elapsed time
                      , lAdam  :: SLocation   -- ^ location of Adam
                      , lLarry :: SLocation   -- ^ location of Larry
                      } deriving (Generic, Mergeable)
+
+-- The derived Mergeable instance is equivalent to the following:
+--
+-- instance Mergeable Status where
+--   symbolicMerge f t s1 s2 = Status { time   = symbolicMerge f t (time   s1) (time   s2)
+--                                    , flash  = symbolicMerge f t (flash  s1) (flash  s2)
+--                                    , lBono  = symbolicMerge f t (lBono  s1) (lBono  s2)
+--                                    , lEdge  = symbolicMerge f t (lEdge  s1) (lEdge  s2)
+--                                    , lAdam  = symbolicMerge f t (lAdam  s1) (lAdam  s2)
+--                                    , lLarry = symbolicMerge f t (lLarry s1) (lLarry s2)
+--                                    }
 
 -- | Start configuration, time elapsed is 0 and everybody is 'here'
 start :: Status


### PR DESCRIPTION
Let me know if you'd prefer me to rebase this on `master`. I'll need to re-remember how to do that in the morning (U.S.). Note that I had accidentally broken the haddock comment for `select`.

I thought to leave one of the old hand-written instances (in the U2 example) for exemplary purposes. After all, that's where I learned how to make the instances work. But I'm not married to the idea; there's always a risk of dead code like that.