### PR TITLE
reap zombies

### DIFF
--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -543,7 +543,7 @@ runSolver cfg execPath opts script
                                                                  else return []
                                                          return $ Just (r, vals)
                              cleanUp response
-      executeSolver `C.onException`  terminateProcess pid
+      executeSolver `C.onException`  (terminateProcess pid >> waitForProcess pid)
 
 -- | In case the SMT-Lib solver returns a response over multiple lines, compress them so we have
 -- each S-Expression spanning only a single line. We'll ignore things line parentheses inside quotes


### PR DESCRIPTION
In case of exceptions, solvers should be not just killed but also waited for; otherwise the child process becomes a zombie, and this leaks a system resource. This is especially bad for users of e.g. `satWithAny`, which uses exceptions to notify the slower solver threads that it's time to die. For example, the following sample program will spawn thousands of zombies without this patch:

    import Control.Monad
    import Data.SBV
    main = forever (satWithAny [z3, cvc4] (literal True))