### PR TITLE
Updated SBV to work with GHC 8.0

### DIFF
--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE    DefaultSignatures          #-}
 {-# LANGUAGE    NamedFieldPuns             #-}
 {-# LANGUAGE    DeriveDataTypeable         #-}
+{-# LANGUAGE    CPP                        #-}
 {-# OPTIONS_GHC -fno-warn-orphans          #-}
 
 module Data.SBV.BitVectors.Symbolic
@@ -343,7 +344,13 @@ instance Show Result where
                         | True     = ", aliasing " ++ show nm
           shui (nm, t) = "  [uninterpreted] " ++ nm ++ " :: " ++ show t
           shax (nm, ss) = "  -- user defined axiom: " ++ nm ++ "\n  " ++ intercalate "\n  " ss
-          shAssert (nm, stk, p) = "  -- assertion: " ++ nm ++ " " ++ maybe "[No location]" showCallStack stk ++ ": " ++ show p
+          shAssert (nm, stk, p) = "  -- assertion: " ++ nm ++ " " ++ maybe "[No location]"
+#if MIN_VERSION_base(4,9,0)
+                prettyCallStack
+#else
+                showCallStack
+#endif
+                stk ++ ": " ++ show p
 
 -- | The context of a symbolic array as created
 data ArrayContext = ArrayFree (Maybe SW)     -- ^ A new array, with potential initializer for each cell
@@ -920,9 +927,14 @@ instance Show SMTLibPgm where
 instance NFData CW where
   rnf (CW x y) = x `seq` y `seq` ()
 
+#if MIN_VERSION_base(4,9,0)
+#else
 -- Can't really force this, but not a big deal
 instance NFData CallStack where
   rnf _ = ()
+#endif
+  
+
 
 instance NFData Result where
   rnf (Result kindInfo qcInfo cgs inps consts tbls arrs uis axs pgm cstr asserts outs)

--- a/GHC/SrcLoc/Compat.hs
+++ b/GHC/SrcLoc/Compat.hs
@@ -4,9 +4,13 @@
 -- longer supported.
 
 #if MIN_VERSION_base(4,8,0)
+module GHC.SrcLoc.Compat (module X) where
 
-module GHC.SrcLoc.Compat (module GHC.SrcLoc) where
-import GHC.SrcLoc
+#if MIN_VERSION_base(4,9,0)
+import SrcLoc as X hiding (srcLocFile)
+#else
+import GHC.SrcLoc as X
+#endif
 
 #else
 

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -48,6 +48,7 @@ Library
     other-extensions: DeriveAnyClass
   Build-Depends   : base >= 4.7 && < 5
                   , base-compat >= 0.6
+                  , ghc
                   , array, async, containers, deepseq, directory, filepath, old-time
                   , pretty, process, mtl, QuickCheck, random, syb, data-binary-ieee754
                   , crackNum


### PR DESCRIPTION
I'm working on a project that uses both the ghc api 8.0 and sbv, so I needed sbv to work with ghc 8.0.
I used this stack.yaml config, in case you want to reproduce this.


```
flags: {}
extra-package-dbs: []
packages:
- '.'
setup-info:
  ghc:
    linux64:
      8.0.0.20160421:
        url: https://downloads.haskell.org/~ghc/8.0.1-rc4/ghc-8.0.0.20160421-x86_64-deb8-linux.tar.xz
        sha1: 6e8bd7c96fa46da0b8c12bf9d62f006940adfe67
extra-deps:
- HUnit-1.3.1.1
- QuickCheck-2.8.2
- async-2.1.0
- base-compat-0.9.1
- crackNum-1.5
- data-binary-ieee754-0.4.4
- ieee754-0.7.8
- mtl-2.2.1
- old-locale-1.0.0.7
- old-time-1.1.0.3
- primitive-0.6.1.0
- random-1.1
- stm-2.4.4.1
- syb-0.6
- tf-random-0.5
compiler: ghc-8.0.0.20160421
resolver: ghc-8.0.0.20160421

```

I also checked that the library still compiles with ghc 7.10.3.
