### PR TITLE
Minor fixes in code generation, and expose more internals

### DIFF
--- a/Data/SBV/Compilers/CodeGen.hs
+++ b/Data/SBV/Compilers/CodeGen.hs
@@ -21,6 +21,7 @@ import Data.Char                 (toLower, isSpace)
 import Data.List                 (nub, isPrefixOf, intercalate, (\\))
 import System.Directory          (createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import System.FilePath           ((</>))
+import System.IO                 (hFlush, stdout)
 
 import           Text.PrettyPrint.HughesPJ      (Doc, vcat)
 import qualified Text.PrettyPrint.HughesPJ as P (render)
@@ -314,6 +315,7 @@ renderCgPgmBundle (Just dirName) (CgPgmBundle _ files) = do
                   _  -> do putStrLn $ "Code generation would override the following " ++ (if length dups == 1 then "file:" else "files:")
                            mapM_ (\fn -> putStrLn ('\t' : fn)) dups
                            putStr "Continue? [yn] "
+                           hFlush stdout
                            resp <- getLine
                            return $ map toLower resp `isPrefixOf` "yes"
         if goOn then do mapM_ renderFile files

--- a/Data/SBV/Compilers/CodeGen.hs
+++ b/Data/SBV/Compilers/CodeGen.hs
@@ -19,7 +19,7 @@ import Control.Monad.Trans
 import Control.Monad.State.Lazy  (MonadState, StateT(..), modify)
 import Data.Char                 (toLower, isSpace)
 import Data.List                 (nub, isPrefixOf, intercalate, (\\))
-import System.Directory          (createDirectory, doesDirectoryExist, doesFileExist)
+import System.Directory          (createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import System.FilePath           ((</>))
 
 import           Text.PrettyPrint.HughesPJ      (Doc, vcat)
@@ -307,7 +307,7 @@ renderCgPgmBundle Nothing        bundle                = print bundle
 renderCgPgmBundle (Just dirName) (CgPgmBundle _ files) = do
         b <- doesDirectoryExist dirName
         unless b $ do putStrLn $ "Creating directory " ++ show dirName ++ ".."
-                      createDirectory dirName
+                      createDirectoryIfMissing True dirName
         dups <- filterM (\fn -> doesFileExist (dirName </> fn)) (map fst files)
         goOn <- case dups of
                   [] -> return True

--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -13,30 +13,27 @@
 
 module Data.SBV.Internals (
   -- * Running symbolic programs /manually/
-  Result(..), SBVRunMode(..), Symbolic, runSymbolic, runSymbolic'
-  -- * Other internal structures useful for low-level programming
-  , SBV(..), slet, CW(..), Kind(..), HasKind(..), CWVal(..), AlgReal(..), Quantifier(..), mkConstCW, genVar, genVar_
-  , liftQRem, liftDMod, symbolicMergeWithKind
-  , cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..)
-  , SBVType(..), newUninterpreted, forceSWArg
+  Result(..), SBVRunMode(..)
+  -- * Internal structures useful for low-level programming
+  , module Data.SBV.BitVectors.Data
   -- * Operations useful for instantiating SBV type classes
-  , genLiteral, genFromCW, genMkSymVar, checkAndConvert, genParse, showModel, SMTModel(..), smtLibReservedNames
+  , genLiteral, genFromCW, genMkSymVar, checkAndConvert, genParse, showModel, SMTModel(..), liftQRem, liftDMod
   -- * Polynomial operations that operate on bit-vectors
   , ites, mdp, addPoly
   -- * Compilation to C
-  , compileToC', compileToCLib', CgPgmBundle(..), CgPgmKind(..)
+  , compileToC', compileToCLib'
+  -- * Code generation primitives
+  , module Data.SBV.Compilers.CodeGen
   -- * Various math utilities around floats
   , module Data.SBV.Utils.Numeric
   ) where
 
-import Data.SBV.BitVectors.Data       ( Result(..), Symbolic, SBVRunMode(..), runSymbolic, runSymbolic', SBV(..), CW(..), Kind(..), HasKind(..), CWVal(..)
-                                      , AlgReal(..), Quantifier(..), mkConstCW, cache, sbvToSW, newExpr, normCW, SBVExpr(..), Op(..), SBVType(..)
-                                      , newUninterpreted, forceSWArg, SMTModel(..))
-import Data.SBV.BitVectors.Model      (genVar, genVar_, slet, liftQRem, liftDMod, symbolicMergeWithKind, genLiteral, genFromCW, genMkSymVar)
+import Data.SBV.BitVectors.Data
+import Data.SBV.BitVectors.Model      (genLiteral, genFromCW, genMkSymVar)
 import Data.SBV.BitVectors.Splittable (checkAndConvert)
+import Data.SBV.BitVectors.Model      (liftQRem, liftDMod, genLiteral, genFromCW, genMkSymVar)
 import Data.SBV.Compilers.C           (compileToC', compileToCLib')
-import Data.SBV.Compilers.CodeGen     (CgPgmBundle(..), CgPgmKind(..))
+import Data.SBV.Compilers.CodeGen
 import Data.SBV.SMT.SMT               (genParse, showModel)
-import Data.SBV.SMT.SMTLibNames       (smtLibReservedNames)
 import Data.SBV.Tools.Polynomial      (ites, mdp, addPoly)
 import Data.SBV.Utils.Numeric


### PR DESCRIPTION
Exposing more of the internal data structures allows code generation targets (other than the already-existing C generator) to be written without having to be included in SBV itself.
