### PR TITLE
Squash some space leaks

### DIFF
--- a/Data/SBV/BitVectors/Concrete.hs
+++ b/Data/SBV/BitVectors/Concrete.hs
@@ -20,11 +20,11 @@ import Data.SBV.BitVectors.Kind
 import Data.SBV.BitVectors.AlgReals
 
 -- | A constant value
-data CWVal = CWAlgReal  AlgReal              -- ^ algebraic real
-           | CWInteger  Integer              -- ^ bit-vector/unbounded integer
-           | CWFloat    Float                -- ^ float
-           | CWDouble   Double               -- ^ double
-           | CWUserSort (Maybe Int, String)  -- ^ value of an uninterpreted/user kind. The Maybe Int shows index position for enumerations
+data CWVal = CWAlgReal  !AlgReal              -- ^ algebraic real
+           | CWInteger  !Integer              -- ^ bit-vector/unbounded integer
+           | CWFloat    !Float                -- ^ float
+           | CWDouble   !Double               -- ^ double
+           | CWUserSort !(Maybe Int, String)  -- ^ value of an uninterpreted/user kind. The Maybe Int shows index position for enumerations
 
 -- | Eq instance for CWVal. Note that we cannot simply derive Eq/Ord, since CWAlgReal doesn't have proper
 -- instances for these when values are infinitely precise reals. However, we do

--- a/Data/SBV/BitVectors/Kind.hs
+++ b/Data/SBV/BitVectors/Kind.hs
@@ -23,7 +23,7 @@ import Data.SBV.BitVectors.AlgReals
 
 -- | Kind of symbolic value
 data Kind = KBool
-          | KBounded Bool Int
+          | KBounded !Bool !Int
           | KUnbounded
           | KReal
           | KUserSort String (Either String [String])

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -27,6 +27,7 @@ source-repository head
 Library
   default-language: Haskell2010
   ghc-options     : -Wall
+  ghc-prof-options: -fprof-auto
   other-extensions: BangPatterns
                     DefaultSignatures
                     DeriveAnyClass


### PR DESCRIPTION
Add strictness annotation in a few strategic places, thereby reducing the amount of garbage created when doing long, essentially concrete, computations.  As far as I can tell, the additional strictness shouldn't be a problem.
