### PR TITLE
Some minor changes that improve performance when dealing with large tables

### DIFF
--- a/Data/SBV/BitVectors/Kind.hs
+++ b/Data/SBV/BitVectors/Kind.hs
@@ -39,6 +39,7 @@ kindRank KReal           = Left 2
 kindRank (KUserSort s _) = Right (Right s)
 kindRank KFloat          = Left 3
 kindRank KDouble         = Left 4
+{-# INLINE kindRank #-}
 
 -- | We want to equate user-sorts only by name
 instance Eq Kind where

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -83,7 +83,7 @@ import Prelude.Compat
 newtype NodeId = NodeId Int deriving (Eq, Ord)
 
 -- | A symbolic word, tracking it's signedness and size.
-data SW = SW Kind NodeId deriving (Eq, Ord)
+data SW = SW !Kind !NodeId deriving (Eq, Ord)
 
 instance HasKind SW where
   kindOf (SW k _) = k

--- a/Data/SBV/SMT/SMTLib2.hs
+++ b/Data/SBV/SMT/SMTLib2.hs
@@ -238,9 +238,10 @@ genTableData rm skolemMap (_quantified, args) consts ((i, aknd, _), elts)
         t           = "table" ++ show i
         mkElt x k   = (isReady, (idx, ssw x))
           where idx = cvtCW rm (mkConstCW aknd k)
-                isReady = x `elem` consts
+                isReady = x `Set.member` constsSet
         topLevel (idx, v) = "(= (" ++ t ++ " " ++ idx ++ ") " ++ v ++ ")"
         nested   (idx, v) = "(= (" ++ t ++ args ++ " " ++ idx ++ ") " ++ v ++ ")"
+        constsSet = Set.fromList consts
 
 -- TODO: We currently do not support non-constant arrays when quantifiers are present, as
 -- we might have to skolemize those. Implement this properly.


### PR DESCRIPTION
Squash some space leaks and use set operations in strategic places.  This
has a huge impact on performance when preforming 'svSelect' on large
tables (2^16 elements) in some examples.
