### PR TITLE
Add option to track timing stats without printing them

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -236,6 +236,7 @@ module Data.SBV (
 
   -- * SMT Interface: Configurations and solvers
   , SMTConfig(..), SMTLibVersion(..), SMTLibLogic(..), Logic(..), OptimizeOpts(..), Solver(..), SMTSolver(..), boolector, cvc4, yices, z3, mathSAT, abc, defaultSolverConfig, sbvCurrentSolver, defaultSMTCfg, sbvCheckSolverInstallation, sbvAvailableSolvers
+  , Timing(..), TimedStep(..), TimingInfo
 
   -- * Symbolic computations
   , Symbolic, output, SymWord(..)
@@ -300,6 +301,7 @@ import Data.SBV.Tools.ExpectedValue
 import Data.SBV.Tools.Optimize
 import Data.SBV.Tools.Polynomial
 import Data.SBV.Utils.Boolean
+import Data.SBV.Utils.TDiff
 import Data.Bits
 import Data.Int
 import Data.Ratio

--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -236,7 +236,7 @@ module Data.SBV (
 
   -- * SMT Interface: Configurations and solvers
   , SMTConfig(..), SMTLibVersion(..), SMTLibLogic(..), Logic(..), OptimizeOpts(..), Solver(..), SMTSolver(..), boolector, cvc4, yices, z3, mathSAT, abc, defaultSolverConfig, sbvCurrentSolver, defaultSMTCfg, sbvCheckSolverInstallation, sbvAvailableSolvers
-  , Timing(..), TimedStep(..), TimingInfo
+  , Timing(..), TimedStep(..), TimingInfo, showTDiff
 
   -- * Symbolic computations
   , Symbolic, output, SymWord(..)

--- a/Data/SBV/BitVectors/Symbolic.hs
+++ b/Data/SBV/BitVectors/Symbolic.hs
@@ -75,6 +75,7 @@ import System.Random
 import Data.SBV.BitVectors.Kind
 import Data.SBV.BitVectors.Concrete
 import Data.SBV.SMT.SMTLibNames
+import Data.SBV.Utils.TDiff(Timing)
 
 import Prelude ()
 import Prelude.Compat
@@ -1053,7 +1054,7 @@ instance HasKind RoundingMode
 -- be printed in their internal memory-layout format as well, which can come in handy for bit-precise analysis.
 data SMTConfig = SMTConfig {
          verbose        :: Bool           -- ^ Debug mode
-       , timing         :: Bool           -- ^ Print timing information on how long different phases took (construction, solving, etc.)
+       , timing         :: Timing         -- ^ Print timing information on how long different phases took (construction, solving, etc.)
        , sBranchTimeOut :: Maybe Int      -- ^ How much time to give to the solver for each call of 'sBranch' check. (In seconds. Default: No limit.)
        , timeOut        :: Maybe Int      -- ^ How much time to give to the solver. (In seconds. Default: No limit.)
        , printBase      :: Int            -- ^ Print integral literals in this base (2, 10, and 16 are supported.)

--- a/Data/SBV/Examples/BitPrecise/Legato.hs
+++ b/Data/SBV/Examples/BitPrecise/Legato.hs
@@ -286,7 +286,7 @@ type Model = SFunArray
 --   On a decent MacBook Pro, this proof takes about 3 minutes with the 'SFunArray' memory model
 --   and about 30 minutes with the 'SArray' model, using yices as the SMT solver
 correctnessTheorem :: IO ThmResult
-correctnessTheorem = proveWith yices{timing = True} $
+correctnessTheorem = proveWith yices{timing = PrintTiming} $
     forAll ["mem", "addrX", "x", "addrY", "y", "addrLow", "regX", "regA", "memVals", "flagC", "flagZ"]
            legatoIsCorrect
 

--- a/Data/SBV/Provers/Prover.hs
+++ b/Data/SBV/Provers/Prover.hs
@@ -61,7 +61,7 @@ import qualified Data.SBV.Provers.ABC        as ABC
 
 mkConfig :: SMTSolver -> SMTLibVersion -> [String] -> SMTConfig
 mkConfig s smtVersion tweaks = SMTConfig { verbose        = False
-                                         , timing         = False
+                                         , timing         = NoTiming
                                          , sBranchTimeOut = Nothing
                                          , timeOut        = Nothing
                                          , printBase      = 10
@@ -463,7 +463,7 @@ simulate converter config isSat comments predicate = do
         let msg = when (verbose config) . putStrLn . ("** " ++)
             isTiming = timing config
         msg "Starting symbolic simulation.."
-        res <- timeIf isTiming "problem construction" $ runSymbolic (isSat, config) $ (if isSat then forSome_ else forAll_) predicate >>= output
+        res <- timeIf isTiming ProblemConstruction $ runSymbolic (isSat, config) $ (if isSat then forSome_ else forAll_) predicate >>= output
         msg $ "Generated symbolic trace:\n" ++ show res
         msg "Translating to SMT-Lib.."
         runProofOn converter config isSat comments res
@@ -474,7 +474,7 @@ runProofOn converter config isSat comments res =
             solverCaps = capabilities (solver config)
         in case res of
              Result ki _qcInfo _codeSegs is consts tbls arrs uis axs pgm cstrs assertions [o@(SW KBool _)] ->
-               timeIf isTiming "translation"
+               timeIf isTiming Translation
                 $ let skolemMap = skolemize (if isSat then is else map flipQ is)
                            where flipQ (ALL, x) = (EX, x)
                                  flipQ (EX, x)  = (ALL, x)

--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -485,7 +485,7 @@ standardSolver config script cleanErrs failure success = do
       Nothing -> return ()
       Just f  -> do msg $ "Saving the generated script in file: " ++ show f
                     writeFile f (scriptBody script)
-    contents <- timeIf isTiming nmSolver $ pipeProcess config  exec opts script cleanErrs
+    contents <- timeIf isTiming (WorkByProver nmSolver) $ pipeProcess config  exec opts script cleanErrs
     msg $ nmSolver ++ " output:\n" ++ either id (intercalate "\n") contents
     case contents of
       Left e   -> return $ failure (lines e)

--- a/Data/SBV/Utils/TDiff.hs
+++ b/Data/SBV/Utils/TDiff.hs
@@ -9,11 +9,33 @@
 -- Runs an IO computation printing the time it took to run it
 -----------------------------------------------------------------------------
 
-module Data.SBV.Utils.TDiff(timeIf) where
+module Data.SBV.Utils.TDiff(timeIf, Timing(..),TimedStep(..),TimingInfo) where
 
 import Control.DeepSeq (rnf, NFData(..))
 import System.Time     (TimeDiff(..), normalizeTimeDiff, diffClockTimes, getClockTime)
 import Numeric         (showFFloat)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.IORef(IORef,modifyIORef')
+
+-- | Specify how to save timing information, if at all.
+data Timing     = NoTiming | PrintTiming | SaveTiming (IORef TimingInfo)
+
+-- | Specify what is being timed.
+data TimedStep  = ProblemConstruction | Translation | WorkByProver String
+                  deriving (Eq,Ord)
+
+-- | A collection of timed stepd.
+type TimingInfo = Map TimedStep TimeDiff
+
+
+timedStepLabel :: TimedStep -> String
+timedStepLabel lbl =
+  case lbl of
+    ProblemConstruction -> "problem construction"
+    Translation         -> "translation"
+    WorkByProver x      -> x
+
 
 showTDiff :: TimeDiff -> String
 showTDiff itd = et
@@ -26,11 +48,22 @@ showTDiff itd = et
 -- | If selected, runs the computation @m@, and prints the time it took
 -- to run it. The return type should be an instance of 'NFData' to ensure
 -- the correct elapsed time is printed.
-timeIf :: NFData a => Bool -> String -> IO a -> IO a
-timeIf False _ m = m
-timeIf True  w m = do start <- getClockTime
-                      r <- m
-                      end <- rnf r `seq` getClockTime
-                      let elapsed = diffClockTimes end start
-                      putStrLn $ "** Elapsed " ++ w ++ " time:" ++ showTDiff elapsed
-                      return r
+timeIf :: NFData a => Timing -> TimedStep -> IO a -> IO a
+timeIf how what m =
+  case how of
+    NoTiming -> m
+    PrintTiming ->
+      do (elapsed,a) <- doTime m
+         putStrLn $ "** Elapsed " ++ timedStepLabel what ++ " time:" ++ showTDiff elapsed
+         return a
+    SaveTiming here ->
+      do (elapsed,a) <- doTime m
+         modifyIORef' here (Map.insert what elapsed)
+         return a
+
+doTime :: NFData a => IO a -> IO (TimeDiff,a)
+doTime m = do start <- getClockTime
+              r <- m
+              end <- rnf r `seq` getClockTime
+              let elapsed = diffClockTimes end start
+              elapsed `seq` return (elapsed, r)

--- a/Data/SBV/Utils/TDiff.hs
+++ b/Data/SBV/Utils/TDiff.hs
@@ -9,7 +9,14 @@
 -- Runs an IO computation printing the time it took to run it
 -----------------------------------------------------------------------------
 
-module Data.SBV.Utils.TDiff(timeIf, Timing(..),TimedStep(..),TimingInfo) where
+module Data.SBV.Utils.TDiff
+  ( timeIf
+  , Timing(..)
+  , TimedStep(..)
+  , TimingInfo
+  , showTDiff
+  )
+  where
 
 import Control.DeepSeq (rnf, NFData(..))
 import System.Time     (TimeDiff(..), normalizeTimeDiff, diffClockTimes, getClockTime)

--- a/Data/SBV/Utils/TDiff.hs
+++ b/Data/SBV/Utils/TDiff.hs
@@ -23,7 +23,7 @@ data Timing     = NoTiming | PrintTiming | SaveTiming (IORef TimingInfo)
 
 -- | Specify what is being timed.
 data TimedStep  = ProblemConstruction | Translation | WorkByProver String
-                  deriving (Eq,Ord)
+                  deriving (Eq,Ord,Show)
 
 -- | A collection of timed stepd.
 type TimingInfo = Map TimedStep TimeDiff


### PR DESCRIPTION
This change allows SBV to track timing information without printing to the screen.  We use this functionality in Cryptol, to print proving statistics in a custom format.

