### PR TITLE
Don't run any int-test-extended tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ install:
 test: install doctest
 	@tput rmam
 	@SBV_Z3=doesnotexist $(TIME) cabal test SBVBasicTests
-	@                    $(TIME) ./dist/build/int-test-extended/int-test-extended -j 4
+	@                    $(TIME) cabal test int-test-extended --test-option='-p ** -j 4'
 	@tput smam
 
 # use this as follows: make gold TGT="cgUSB5"
 gold: 
-	./dist/build/int-test-extended/int-test-extended -p ${TGT} --accept
+	cabal test int-test-extended --test-option="-p ${TGT}"
 
 doctest:
 	@tput rmam

--- a/SBVUnitTest/SBVIntTest.hs
+++ b/SBVUnitTest/SBVIntTest.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Main(main) where
 
 import Test.Tasty
+import Test.Tasty.Runners (noPattern, TestPattern)
 import qualified TestSuite.Arrays.Memory
 import qualified TestSuite.Basics.ArithSolver
 import qualified TestSuite.Basics.Higher
@@ -31,7 +33,15 @@ import qualified TestSuite.Uninterpreted.Sort
 import qualified TestSuite.Uninterpreted.Uninterpreted
 
 main :: IO ()
-main = defaultMain (testGroup "Tests" tests)
+main =
+  defaultMain
+    (askOption
+      (\(v :: TestPattern) ->
+        testGroup
+          "Tests"
+          (if (show v == show noPattern)
+             then []
+             else tests)))
 
 tests :: [TestTree]
 tests =


### PR DESCRIPTION
- override tasty's pattern matching behavior to consider no pattern provided as skip all tests (https://github.com/LeventErkok/sbv/issues/274)

If you change the makefile to invoke the tests with `TASTY_PATTERN='**' cabal ...` when you want to run the solver tests, then this should all work for Stack and Nix.

Notes, on other attempts:
- adjustOption doesn't seem to work in my attempts here
- askOption and setting a new TestPattern value didn't work in my attempts
- TestPattern doesn't implement Eq, so I used a hack with Show.

It appears as though the "pattern" option is not overrideable at runtime, so I resorted to producing an empty test suite.

I think this is preferable to a Cabal flag, because it avoids Cabal building the library two times, once for basic tests, once for int-test-extended. But I haven't confirmed that suspicion.