### PR TITLE
Add a note about SMT solver versions to main haddocks

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -98,6 +98,9 @@
 --
 --   * Z3 from Microsoft: <http://github.com/Z3Prover/z3/wiki>
 --
+-- SBV requires recent versions of these solvers; please see the file
+-- @SMTSolverVersions.md@ in the source distribution for specifics.
+--
 -- SBV also allows calling these solvers in parallel, either getting results from multiple solvers
 -- or returning the fastest one. (See 'proveWithAll', 'proveWithAny', etc.)
 --


### PR DESCRIPTION
This is trivial but may save time for those (like me) who read the haddocks first by default.