### PR TITLE
Export AlgReals.Polynomial under new name PolyRep in Internals

### DIFF
--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -28,7 +28,7 @@ module Data.SBV.Core.Data
  , sRoundNearestTiesToEven, sRoundNearestTiesToAway, sRoundTowardPositive, sRoundTowardNegative, sRoundTowardZero
  , sRNE, sRNA, sRTP, sRTN, sRTZ
  , SymWord(..)
- , CW(..), CWVal(..), AlgReal(..), ExtCW(..), GeneralizedCW(..), isRegularCW, cwSameType, cwToBool
+ , CW(..), CWVal(..), AlgReal(..), PolyRep, ExtCW(..), GeneralizedCW(..), isRegularCW, cwSameType, cwToBool
  , mkConstCW ,liftCW2, mapCW, mapCW2
  , SW(..), trueSW, falseSW, trueCW, falseCW, normCW
  , SVal(..)


### PR DESCRIPTION
To be able to use the AlgReal type exported in Data.SBV.Internals one also needs the Polynomial newtype from Data.SBV.Core.AlgReals. However we can't simply export this under that name, as it clashes with Polynomial from Data.SBV.Polynomial. Therefore I renamed it to PolyRep.