### PR TITLE
Expose registerKind via Data.SBV.Internals

### DIFF
--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -22,7 +22,7 @@ module Data.SBV.Internals (
   , module Data.SBV.Core.Data
 
   -- * Operations useful for instantiating SBV type classes
-  , genLiteral, genFromCW, CW(..), genMkSymVar, genParse, showModel, SMTModel(..), liftQRem, liftDMod
+  , genLiteral, genFromCW, CW(..), genMkSymVar, genParse, showModel, SMTModel(..), liftQRem, liftDMod, registerKind
 
   -- * Compilation to C, extras
   , compileToC', compileToCLib'
@@ -50,7 +50,7 @@ module Data.SBV.Internals (
 
 import Data.SBV.Core.Data
 import Data.SBV.Core.Model      (genLiteral, genFromCW, genMkSymVar, liftQRem, liftDMod)
-import Data.SBV.Core.Symbolic   (IStage(..), addSValOptGoal)
+import Data.SBV.Core.Symbolic   (IStage(..), addSValOptGoal, registerKind)
 
 import Data.SBV.Compilers.C       (compileToC', compileToCLib')
 import Data.SBV.Compilers.CodeGen


### PR DESCRIPTION
Re: 77858f3, this function is necessary for clients to be able to re-implement the "legacy" `SFunArray` in userspace.