### PR TITLE
List extras

### DIFF
--- a/SBVTestSuite/TestSuite/Basics/List.hs
+++ b/SBVTestSuite/TestSuite/Basics/List.hs
@@ -41,7 +41,7 @@ tests =
     , goldenCapturedIO "seqExamples6"  $ \rf -> checkWith z3{redirectVerbose=Just rf} seqExamples6    Unsat
     , goldenCapturedIO "seqExamples7"  $ \rf -> checkWith z3{redirectVerbose=Just rf} seqExamples7    Sat
     , goldenCapturedIO "seqExamples8"  $ \rf -> checkWith z3{redirectVerbose=Just rf} seqExamples8    Unsat
-    , testCase         "seqExamples9"  $ assert strExamples9
+    , testCase         "seqExamples9"  $ assert seqExamples9
     ]
 
 checkWith :: SMTConfig -> Symbolic () -> CheckSatResult -> IO ()
@@ -131,8 +131,8 @@ seqExamples8 = do
   constrain $ bnot $ a .== b .++ c
 
 -- Generate all length one sequences, to enumerate all and making sure we can parse correctly
-strExamples9 :: IO Bool
-strExamples9 = do m <- allSat $ do (s :: SList Word8) <- sList "s"
+seqExamples9 :: IO Bool
+seqExamples9 = do m <- allSat $ do (s :: SList Word8) <- sList "s"
                                    return $ L.length s .== 1
 
                   let vals :: [Word8]


### PR DESCRIPTION
Hi Levent, this is a request for feedback -- not a PR I intend to have merged.

I set out intending to think about sortedness of lists. I thought I might implement list sorting symbolically, but decided to start with the more modest goal of implementing `isSorted` (which I failed at).

We can start from the concrete haskell implementation `isSorted lst = and $ zipWith (<=) lst (tail lst)`. The sbv implementation looks pretty similar. It works on concrete lists, but fails otherwise.

The bit that gave me trouble was the equivalent to `and`. SBV of course includes `bAnd :: Boolean b => [b] -> b`, but we need something with signature `bAnd' :: SList Bool -> SBV Bool`. I chose to implement this in terms of `foldr` (`foldl` was also easy to define (though neither works)). Unfortunately, this implementation hangs for 30s then stack overflows. From the definition of `foldr` I'd guess we're repeatedly expanding the recursive `foldr` and never making any progress.

Two things to note here:

1. Note that the list I'm testing with has a statically determined length. If we could access that length then it would be possible to expand foldr. Though this wouldn't solve the problem in general.
2. These functions (`fold*`, `bAnd'`, `isSorted`, etc) seem to me like common needs. It'd be a shame if we couldn't support them. However, they don't seem naturally supported by the z3 api.

My other idea was to implement this using quantification:

```
isSorted :: (Typeable a, SymWord a) => SList a -> Symbolic SBool
isSorted lst
  | Just cLst <- unliteral lst
  = pure $ literal $ and $ L.zipWith (<=) cLst (L.tail cLst)
  | True
  = do ix <- forall "ix"
       let len = length lst
       pure $ ix .< len - 1 ==> lst .!! ix .<= lst .!! (ix + 1)
```

Unfortunately, this doesn't work either:

```
*** Data.SBV: Unsupported query call in the presence of quantified inputs.
***
*** The following variable requires explicit quantification: 
***
***    ix
***
*** While quantification and queries can co-exist in principle, SBV currently
*** does not support this scenario. Avoid using quantifiers with user queries
*** if possible. Please do get in touch if your use case does require such
*** a feature to see how we can accommodate such scenarios.
```

I'd love your thoughts / suggestions.