### PR TITLE
Restore existing duration after timeout completes

### DIFF
--- a/Data/SBV/Control/Utils.hs
+++ b/Data/SBV/Control/Utils.hs
@@ -718,10 +718,13 @@ getUnsatAssumptions originals proxyMap = do
 --
 -- If the solver responds within the time-out specified, then we continue as usual. However, if the backend solver times-out
 -- using this mechanism, there is no telling what the state of the solver will be. Thus, we raise an error in this case.
+--
+-- After this supplied timeout is applied to every call in @q@, the previous timeout value is restored.
 timeout :: Int -> Query a -> Query a
-timeout n q = do modifyQueryState (\qs -> qs {queryTimeOutValue = Just n})
+timeout n q = do prevTimeOut <- queryTimeOutValue <$> getQueryState
+                 modifyQueryState (\qs -> qs {queryTimeOutValue = Just n})
                  r <- q
-                 modifyQueryState (\qs -> qs {queryTimeOutValue = Nothing})
+                 modifyQueryState (\qs -> qs {queryTimeOutValue = prevTimeOut})
                  return r
 
 -- | Bail out if a parse goes bad


### PR DESCRIPTION
Hi Levent,

I noticed that `timeout` doesn't restore the previous duration after running the provided query, and thought you might like to change that.

Brian