### PR TITLE
Document partiality of Eq and EqSymbolic instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
     supported.
 
 ### Version 7.10, 2018-07-20
+  * [BACKWARDS COMPATIBILITY] '==' and '/=' now always throw an error instead of
+    only throwing an error for non-concrete values.
+    https://github.com/LeventErkok/sbv/issues/301
 
   * [BACKWARDS COMPATIBILITY] Array declarations are reworked to take
     an initial value. The call 'newArray' now accepts an optional default

--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -243,14 +243,14 @@ sRTZ :: SRoundingMode
 sRTZ = sRoundTowardZero
 
 -- | A 'Show' instance is not particularly "desirable," when the value is symbolic,
--- but we do need this instance as otherwise we cannot simply evaluate Haskell functions 
+-- but we do need this instance as otherwise we cannot simply evaluate Haskell functions
 -- that return symbolic values and have their constant values printed easily!
 instance Show (SBV a) where
   show (SBV sv) = show sv
 
--- | Equality constraint on SBV values. Not desirable since we can't really compare two
--- symbolic values, but will do. Note that we do need this instance since we want
--- Bits as a class for SBV that we implement, which necessiates the Eq class.
+-- | This instance is only defined so that we can define an instance for
+-- 'Data.Bits.Bits'. '==' and '/=' simply throw an error. Use
+-- 'Data.SBV.EqSymbolic' instead.
 instance Eq (SBV a) where
   SBV a == SBV b = a == b
   SBV a /= SBV b = a /= b

--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -946,6 +946,8 @@ lift2FNS nm f sv1 sv2
 
 -- NB. In the optimizations below, use of -1 is valid as
 -- -1 has all bits set to True for both signed and unsigned values
+-- | Using 'popCount' or 'testBit' on non-concrete values will result in an
+-- error. Use 'sPopCount' or 'sTestBit' instead.
 instance (Num a, Bits a, SymWord a) => Bits (SBV a) where
   SBV x .&. SBV y    = SBV (svAnd x y)
   SBV x .|. SBV y    = SBV (svOr x y)

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -799,6 +799,8 @@ instance Show SVal where
 -- We really don't want an 'Eq' instance for 'SBV' or 'SVal'. As it really makes no sense.
 -- But since we do want the 'Bits' instance, we're forced to define equality. See
 -- <http://github.com/LeventErkok/sbv/issues/301>. We simply error out.
+-- | This instance is only defined so that we can define an instance for
+-- 'Data.Bits.Bits'. '==' and '/=' simply throw an error.
 instance Eq SVal where
   a == b = error $ "Comparing symbolic bit-vectors; Use (.==) instead. Received: " ++ show (a, b)
   a /= b = error $ "Comparing symbolic bit-vectors; Use (./=) instead. Received: " ++ show (a, b)


### PR DESCRIPTION
See #301. I also added an entry to CHANGES.md for 7.10 that the `Eq` instance was made to always throw an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leventerkok/sbv/432)
<!-- Reviewable:end -->
