### PR TITLE
Support generating classes of named variables

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -322,6 +322,7 @@ module Data.SBV (
   , SymVal, forall, forall_, mkForallVars, exists, exists_, mkExistVars, free
   , free_, mkFreeVars, symbolic, symbolics, literal, unliteral, fromCV
   , isConcrete, isSymbolic, isConcretely, mkSymVal
+  , VariableName(..)
   , MonadSymbolic(..), Symbolic, SymbolicT, label, output, runSMT, runSMTWith
 
   -- * Module exports
@@ -352,7 +353,7 @@ import Data.SBV.Core.Model      hiding (assertWithPenalty, minimize, maximize,
                                         sMaybe, sMaybe_, sMaybes, sEither, sEither_, sEithers, sSet, sSet_, sSets)
 import Data.SBV.Core.Floating
 import Data.SBV.Core.Splittable
-import Data.SBV.Core.Symbolic   (MonadSymbolic(..), SymbolicT)
+import Data.SBV.Core.Symbolic   (MonadSymbolic(..), SymbolicT, VariableName(..))
 
 import Data.SBV.Provers.Prover hiding (forAll_, forAll, forSome_, forSome,
                                        prove, proveWith, sat, satWith, allSat,

--- a/Data/SBV/Client/BaseIO.hs
+++ b/Data/SBV/Client/BaseIO.hs
@@ -22,7 +22,7 @@ import Data.SBV.Core.Data      (HasKind, Kind, Outputtable, Penalty, SymArray,
                                 SWord64, SEither, SMaybe, SSet)
 import Data.SBV.Core.Model     (Metric)
 import Data.SBV.Core.Symbolic  (Objective, OptimizeStyle, Quantifier, Result,
-                                Symbolic, SBVRunMode, SMTConfig, SVal)
+                                Symbolic, SBVRunMode, SMTConfig, SVal, VariableName)
 import Data.SBV.Control.Types  (SMTOption)
 import Data.SBV.Provers.Prover (Provable, SExecutable, ThmResult)
 import Data.SBV.SMT.SMT        (AllSatResult, SafeResult, SatResult,
@@ -207,7 +207,7 @@ safeWith = Trans.safeWith
 -- | Create a symbolic variable.
 --
 -- NB. For a version which generalizes over the underlying monad, see 'Data.SBV.Trans.mkSymSBV'
-mkSymSBV :: Maybe Quantifier -> Kind -> Maybe String -> Symbolic (SBV a)
+mkSymSBV :: Maybe Quantifier -> Kind -> VariableName -> Symbolic (SBV a)
 mkSymSBV = Trans.mkSymSBV
 
 -- | Convert a symbolic value to an SV, inside the Symbolic monad
@@ -292,7 +292,7 @@ symbolics = Trans.symbolics
 -- | One stop allocator
 --
 -- NB. For a version which generalizes over the underlying monad, see 'Data.SBV.Trans.mkSymVal'
-mkSymVal :: SymVal a => Maybe Quantifier -> Maybe String -> Symbolic (SBV a)
+mkSymVal :: SymVal a => Maybe Quantifier -> VariableName -> Symbolic (SBV a)
 mkSymVal = Trans.mkSymVal
 
 -- | Create a new anonymous array, possibly with a default initial value.
@@ -312,7 +312,7 @@ newArray = Trans.newArray
 -- | Generically make a symbolic var
 --
 -- NB. For a version which generalizes over the underlying monad, see 'Data.SBV.Trans.genMkSymVar'
-genMkSymVar :: Kind -> Maybe Quantifier -> Maybe String -> Symbolic (SBV a)
+genMkSymVar :: Kind -> Maybe Quantifier -> VariableName -> Symbolic (SBV a)
 genMkSymVar = Trans.genMkSymVar
 
 -- | Declare a named 'SBool'

--- a/Data/SBV/Compilers/CodeGen.hs
+++ b/Data/SBV/Compilers/CodeGen.hs
@@ -53,7 +53,7 @@ import           Text.PrettyPrint.HughesPJ      (Doc, vcat)
 import qualified Text.PrettyPrint.HughesPJ as P (render)
 
 import Data.SBV.Core.Data
-import Data.SBV.Core.Symbolic (MonadSymbolic(..), svToSymSV, svMkSymVar, outputSVal)
+import Data.SBV.Core.Symbolic (MonadSymbolic(..), svToSymSV, svMkSymVar, outputSVal, VariableName(..))
 
 #if MIN_VERSION_base(4,11,0)
 import Control.Monad.Fail as Fail
@@ -206,7 +206,7 @@ cgAddLDFlags ss = modify' (\s -> s { cgLDFlags = cgLDFlags s ++ ss })
 
 -- | Creates an atomic input in the generated code.
 svCgInput :: Kind -> String -> SBVCodeGen SVal
-svCgInput k nm = do r  <- symbolicEnv >>= liftIO . svMkSymVar (Just ALL) k Nothing
+svCgInput k nm = do r  <- symbolicEnv >>= liftIO . svMkSymVar (Just ALL) k (NameClass "svCgInput")
                     sv <- svToSymSV r
                     modify' (\s -> s { cgInputs = (nm, CgAtomic sv) : cgInputs s })
                     return r
@@ -215,7 +215,7 @@ svCgInput k nm = do r  <- symbolicEnv >>= liftIO . svMkSymVar (Just ALL) k Nothi
 svCgInputArr :: Kind -> Int -> String -> SBVCodeGen [SVal]
 svCgInputArr k sz nm
   | sz < 1 = error $ "SBV.cgInputArr: Array inputs must have at least one element, given " ++ show sz ++ " for " ++ show nm
-  | True   = do rs  <- symbolicEnv >>= liftIO . replicateM sz . svMkSymVar (Just ALL) k Nothing
+  | True   = do rs  <- symbolicEnv >>= liftIO . replicateM sz . svMkSymVar (Just ALL) k (NameClass "svCgInputArr")
                 sws <- mapM svToSymSV rs
                 modify' (\s -> s { cgInputs = (nm, CgArray sws) : cgInputs s })
                 return rs

--- a/Data/SBV/Control/Utils.hs
+++ b/Data/SBV/Control/Utils.hs
@@ -82,6 +82,7 @@ import Data.SBV.Core.Symbolic ( IncState(..), withNewIncState, State(..), svToSV
                               , registerLabel, svMkSymVar
                               , isSafetyCheckingIStage, isSetupIStage, isRunIStage, IStage(..), QueryT(..)
                               , extractSymbolicSimulationState, MonadSymbolic(..), newUninterpreted
+                              , VariableName(..)
                               )
 
 import Data.SBV.Core.AlgReals   (mergeAlgReals)
@@ -223,12 +224,12 @@ instance (MonadIO m, SymVal a, SMTValue a, Foldable t, Traversable t, Fresh m (t
 
 -- | Generalization of 'Data.SBV.Control.freshVar_'
 freshVar_ :: forall a m. (MonadIO m, MonadQuery m, SymVal a) => m (SBV a)
-freshVar_ = inNewContext $ fmap SBV . svMkSymVar (Just EX) k Nothing
+freshVar_ = inNewContext $ fmap SBV . svMkSymVar (Just EX) k Unnamed
   where k = kindOf (Proxy @a)
 
 -- | Generalization of 'Data.SBV.Control.freshVar'
 freshVar :: forall a m. (MonadIO m, MonadQuery m, SymVal a) => String -> m (SBV a)
-freshVar nm = inNewContext $ fmap SBV . svMkSymVar (Just EX) k (Just nm)
+freshVar nm = inNewContext $ fmap SBV . svMkSymVar (Just EX) k (UniqueName nm)
   where k = kindOf (Proxy @a)
 
 -- | Generalization of 'Data.SBV.Control.freshArray_'

--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -368,7 +368,7 @@ sbvToSV st (SBV s) = svToSV st s
 -------------------------------------------------------------------------
 
 -- | Generalization of 'Data.SBV.mkSymSBV'
-mkSymSBV :: forall a m. MonadSymbolic m => Maybe Quantifier -> Kind -> Maybe String -> m (SBV a)
+mkSymSBV :: forall a m. MonadSymbolic m => Maybe Quantifier -> Kind -> VariableName -> m (SBV a)
 mkSymSBV mbQ k mbNm = SBV <$> (symbolicEnv >>= liftIO . svMkSymVar mbQ k mbNm)
 
 -- | Generalization of 'Data.SBV.sbvToSymSW'
@@ -455,7 +455,7 @@ instance (Outputtable a, Outputtable b, Outputtable c, Outputtable d, Outputtabl
 -- | A 'SymVal' is a potential symbolic value that can be created instances of to be fed to a symbolic program.
 class (HasKind a, Typeable a) => SymVal a where
   -- | Generalization of 'Data.SBV.mkSymVal'
-  mkSymVal :: MonadSymbolic m => Maybe Quantifier -> Maybe String -> m (SBV a)
+  mkSymVal :: MonadSymbolic m => Maybe Quantifier -> VariableName -> m (SBV a)
   -- | Turn a literal constant to symbolic
   literal :: a -> SBV a
   -- | Extract a literal, from a CV representation
@@ -467,7 +467,7 @@ class (HasKind a, Typeable a) => SymVal a where
   -- Giving no instances is okay when defining an uninterpreted/enumerated sort, but otherwise you really
   -- want to define: literal, fromCV, mkSymVal
 
-  default mkSymVal :: (MonadSymbolic m, Read a, G.Data a) => Maybe Quantifier -> Maybe String -> m (SBV a)
+  default mkSymVal :: (MonadSymbolic m, Read a, G.Data a) => Maybe Quantifier -> VariableName -> m (SBV a)
   mkSymVal mbQ mbNm = SBV <$> (symbolicEnv >>= liftIO . svMkSymVar mbQ k mbNm)
     where -- NB.A call of the form
           --      constructUKind (Proxy @a)
@@ -493,11 +493,11 @@ class (HasKind a, Typeable a) => SymVal a where
 
   -- | Generalization of 'Data.SBV.forall'
   forall :: MonadSymbolic m => String -> m (SBV a)
-  forall = mkSymVal (Just ALL) . Just
+  forall = mkSymVal (Just ALL) . UniqueName
 
   -- | Generalization of 'Data.SBV.forall_'
   forall_ :: MonadSymbolic m => m (SBV a)
-  forall_ = mkSymVal (Just ALL) Nothing
+  forall_ = mkSymVal (Just ALL) Unnamed
 
   -- | Generalization of 'Data.SBV.mkForallVars'
   mkForallVars :: MonadSymbolic m => Int -> m [SBV a]
@@ -505,11 +505,11 @@ class (HasKind a, Typeable a) => SymVal a where
 
   -- | Generalization of 'Data.SBV.exists'
   exists :: MonadSymbolic m => String -> m (SBV a)
-  exists = mkSymVal (Just EX) . Just
+  exists = mkSymVal (Just EX) . UniqueName
 
   -- | Generalization of 'Data.SBV.exists_'
   exists_ :: MonadSymbolic m => m (SBV a)
-  exists_ = mkSymVal (Just EX) Nothing
+  exists_ = mkSymVal (Just EX) Unnamed
 
   -- | Generalization of 'Data.SBV.mkExistVars'
   mkExistVars :: MonadSymbolic m => Int -> m [SBV a]
@@ -517,11 +517,11 @@ class (HasKind a, Typeable a) => SymVal a where
 
   -- | Generalization of 'Data.SBV.free'
   free :: MonadSymbolic m => String -> m (SBV a)
-  free = mkSymVal Nothing . Just
+  free = mkSymVal Nothing . UniqueName
 
   -- | Generalization of 'Data.SBV.free_'
   free_ :: MonadSymbolic m => m (SBV a)
-  free_ = mkSymVal Nothing Nothing
+  free_ = mkSymVal Nothing Unnamed
 
   -- | Generalization of 'Data.SBV.mkFreeVars'
   mkFreeVars :: MonadSymbolic m => Int -> m [SBV a]

--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -82,13 +82,17 @@ import Data.SBV.Utils.Lib      (isKString)
 
 -- Symbolic-Word class instances
 
--- | Generate a finite symbolic bitvector, named
+-- | Generate a finite symbolic bitvector, uniquely named
 genVar :: MonadSymbolic m => Maybe Quantifier -> Kind -> String -> m (SBV a)
-genVar q k = mkSymSBV q k . Just
+genVar q k = mkSymSBV q k . UniqueName
+
+-- | Generate a finite symbolic bitvector, named as one of a class of variables
+genClassVar :: MonadSymbolic m => Maybe Quantifier -> Kind -> String -> m (SBV a)
+genClassVar q k = mkSymSBV q k . NameClass
 
 -- | Generate a finite symbolic bitvector, unnamed
 genVar_ :: MonadSymbolic m => Maybe Quantifier -> Kind -> m (SBV a)
-genVar_ q k = mkSymSBV q k Nothing
+genVar_ q k = mkSymSBV q k Unnamed
 
 -- | Generate a finite constant bitvector
 genLiteral :: Integral a => Kind -> a -> SBV b
@@ -100,9 +104,10 @@ genFromCV (CV _ (CInteger x)) = fromInteger x
 genFromCV c                   = error $ "genFromCV: Unsupported non-integral value: " ++ show c
 
 -- | Generalization of 'Data.SBV.genMkSymVar'
-genMkSymVar :: MonadSymbolic m => Kind -> Maybe Quantifier -> Maybe String -> m (SBV a)
-genMkSymVar k mbq Nothing  = genVar_ mbq k
-genMkSymVar k mbq (Just s) = genVar  mbq k s
+genMkSymVar :: MonadSymbolic m => Kind -> Maybe Quantifier -> VariableName -> m (SBV a)
+genMkSymVar k mbq Unnamed        = genVar_     mbq k
+genMkSymVar k mbq (UniqueName s) = genVar      mbq k s
+genMkSymVar k mbq (NameClass s)  = genClassVar mbq k s
 
 instance SymVal Bool where
   mkSymVal = genMkSymVar KBool


### PR DESCRIPTION
Hi Levent,

@bts and I have a few places in our code where we programmatically generate sbv variables using, eg, `exists`. I'd like to be able to use the same name in each of these places, eg, `"tag"` or `"user_var"`. Unfortunately we can't do that today because of the requirement that names be unique. This PR adds a new type of variable allocation which allows duplicate names. I've already found this useful in debugging:

Old:

```
*** Exception:
*** Data.SBV: Unsupported query call in the presence of quantified inputs.
***
*** The following variable requires explicit quantification:
***
***    s55
***
*** While quantification and queries can co-exist in principle, SBV currently
*** does not support this scenario. Avoid using quantifiers with user queries
*** if possible. Please do get in touch if your use case does require such
*** a feature to see how we can accommodate such scenarios.
```

New:

```
*** Exception:
*** Data.SBV: Unsupported query call in the presence of quantified inputs.
***
*** The following variable requires explicit quantification:
***
***    forall_row55
***
*** While quantification and queries can co-exist in principle, SBV currently
*** does not support this scenario. Avoid using quantifiers with user queries
*** if possible. Please do get in touch if your use case does require such
*** a feature to see how we can accommodate such scenarios.
```

So I'm curious whether this is something you'd like to have in sbv.

Note that this first commit contains a bug. This example could blow up in the "repeated user name" check in `introduceUserName`:

```haskell
mkSymVal Nothing (NameClass "foo")
mkSymVal Nothing (UniqueName "foo1")
```

I'll fix this if you're interested in taking this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leventerkok/sbv/457)
<!-- Reviewable:end -->
