### PR TITLE
Corrected comment for Diophantine Equations example

### DIFF
--- a/Documentation/SBV/Examples/Existentials/Diophantine.hs
+++ b/Documentation/SBV/Examples/Existentials/Diophantine.hs
@@ -45,7 +45,7 @@ ldn mbLim problem = do solution <- basis mbLim (map (map literal) m)
 
 -- | Find the basis solution. By definition, the basis has all non-trivial (i.e., non-0) solutions
 -- that cannot be written as the sum of two other solutions. We use the mathematically equivalent
--- statement that a solution is in the basis if it's least according to the lexicographic
+-- statement that a solution is in the basis if it's least according to the natural partial
 -- order using the ordinary less-than relation. (NB. We explicitly tell z3 to use the logic
 -- AUFLIA for this problem, as the BV solver that is chosen automatically has a performance
 -- issue. See: <http://z3.codeplex.com/workitem/88>.)


### PR DESCRIPTION
After playing with it a bit, the code actually doesn't get much simpler when modified - and the extra constraints left in at the moment for `basis` on line 60 mean it might be able to short-cut some calculations, so I have left it as-is.

So this only corrects the comment which suggests we are using the lexicographic ordering - we are using the so-called natural partial order, where `a <= b` for each component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leventerkok/sbv/464)
<!-- Reviewable:end -->
