### PR TITLE
adding disclaimer regarding non-z3 solvers in query mode

### DIFF
--- a/Data/SBV/Control.hs
+++ b/Data/SBV/Control.hs
@@ -154,7 +154,7 @@ they allow direct control of the solver. Here's a simple example:
 
 Note the type of @test@: it returns an optional pair of integers in the 'Symbolic' monad. We turn
 it into an IO value with the 'Data.SBV.Control.runSMT' function: (There's also 'Data.SBV.Control.runSMTWith' that uses a user specified
-solver instead of the default.)
+solver instead of the default. Note that 'Data.SBV.Provers.z3' is best supported (and tested), if you use another solver your results may vary!)
 
 @
     pair :: IO (Maybe (Integer, Integer))


### PR DESCRIPTION
See #485 for details. 

This is just a documentation change to let user's know that it is recommended to use `z3` with query mode.

Let me know if you want me to change/add anything.