### PR TITLE
SBV benchmark suite, phase 1 with puzzle benchmarks

### DIFF
--- a/SBVBenchSuite/BenchSuite/Overhead/SBVOverhead.hs
+++ b/SBVBenchSuite/BenchSuite/Overhead/SBVOverhead.hs
@@ -1,0 +1,208 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Batch.SBVOverhead
+-- Copyright : (c) Jeffrey Young
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Assessing the overhead of calling solving examples via sbv vs individual solvers
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+
+module BenchSuite.Overhead.SBVOverhead
+  ( runner
+  , runner'
+  , runnerWith
+  , rGroup
+  , mkOverheadBenchMark
+  , onConfig
+  , onDesc
+  , setRunner
+  , onProblem
+  , Runner(..)
+  , using
+  ) where
+
+import           Control.DeepSeq         (NFData (..), rwhnf)
+import           System.Directory        (getCurrentDirectory)
+import           System.IO
+
+import           Criterion.Main
+
+import qualified System.Process          as P
+import qualified Utils.SBVBenchFramework as U
+
+-- | The type of the problem to benchmark. This allows us to operate on Runners
+-- as values themselves yet still have a unified interface with criterion.
+data Problem = forall a . U.Provable a => Problem a
+
+-- | Similarly to Problem, BenchResult is boilerplate for a nice api
+data BenchResult = forall a . (Show a, NFData a) => BenchResult a
+
+-- | A bench unit is a solver and a problem that represents an input problem
+-- for the solver to solve
+type BenchUnit = (U.SMTConfig, FilePath)
+
+-- | A runner is anything that allows the solver to solve, such as:
+-- 'Data.SBV.proveWith' or 'Data.SBV.satWith'. We utilize existential types to
+-- lose type information and create a unified interface with criterion. We
+-- require a runner in order to generate a 'Data.SBV.transcript' and then to run
+-- the actual benchmark. We bundle this redundantly into a record so that the
+-- benchmarks can be defined in each respective module, with the run function
+-- that makes sense for that problem, and then redefined in 'SBVBench'. This is
+-- useful because problems that require 'Data.SBV.allSatWith' can lead to a lot
+-- of variance in the benchmarking data. Single benchmark runners like
+-- 'Data.SBV.satWith' and 'Data.SBV.proveWith' work best.
+data RunnerI = RunnerI { run         :: (U.SMTConfig -> Problem -> IO BenchResult)
+                       , config      :: U.SMTConfig
+                       , description :: String
+                       , problem     :: Problem
+}
+
+-- | GADT to allow arbritrary nesting of runners. This copies criterion's design
+-- so that we don't have to separate out runners that run a single benchmark
+-- from runners that need to run several benchmarks
+data Runner where
+  Runner :: RunnerI -> Runner           -- ^ a single run
+  RunnerGroup :: [Runner] -> Runner     -- ^ a group of runs
+
+-- | Convenience boilerplate functions, simply avoiding a lens dependency
+using :: Runner -> (Runner -> Runner) -> Runner
+using = flip ($)
+
+setRunner :: (Show c, NFData c) =>
+  (forall a. U.Provable a => U.SMTConfig -> a -> IO c) -> Runner -> Runner
+setRunner r' (Runner r@RunnerI{..}) = Runner $ r{run = toRun r'}
+setRunner r' (RunnerGroup rs)       = RunnerGroup $ setRunner r' <$> rs
+
+toRun :: (Show c, NFData c) =>
+  (forall a. U.Provable a => U.SMTConfig -> a -> IO c)
+  -> U.SMTConfig
+  -> Problem
+  -> IO BenchResult
+toRun f c p = BenchResult <$> helper p
+  -- simpler to helper in onProblem, this is lmap from profunctor land, i.e., we
+  -- curry with a config, then change the runner function from (a -> IO c), to
+  -- (Problem -> IO c)
+  where helper (Problem a) = f c a
+
+onConfig :: (U.SMTConfig -> U.SMTConfig) -> RunnerI -> RunnerI
+onConfig f r@RunnerI{..} = r{config = f config}
+
+onDesc :: (String -> String) -> RunnerI -> RunnerI
+onDesc f r@RunnerI{..} = r{description = f description}
+
+onProblem :: (forall a. a -> a) -> RunnerI -> RunnerI
+onProblem f r@RunnerI{..} = r{problem = (helper problem)}
+  where
+    -- helper function to avoid profunctor dependency, this is simply fmap, or
+    -- rmap for profunctor land
+    helper :: Problem -> Problem
+    helper (Problem p) = Problem $ f p
+
+
+-- | Filepath to /dev/null
+devNull :: FilePath
+#ifndef WINDOWS
+devNull = "/dev/null"
+#else
+devNull = "NUL"
+#endif
+
+-- | to bench a solver without interfacing through SBV we call transcript to
+-- have SBV generate the input file for the solver and then create a process to
+-- initiate execution on the solver. Note that we redirect stdout to /dev/devNull
+-- or NUL on windows
+runStandaloneSolver :: BenchUnit -> IO ()
+runStandaloneSolver (slvr, fname) =
+  withFile devNull WriteMode $
+  (\h -> do (_,_,_,ph) <- P.createProcess (P.shell command){P.std_out = P.UseHandle h}
+            _ <- P.waitForProcess ph
+            return ())
+  where command = U.mkExecString slvr fname
+
+-- | Given a file name, a solver config, and a problem to solve, create an
+-- environment for the criterion benchmark by generating a transcript file
+standaloneEnv :: RunnerI -> IO FilePath -> IO BenchUnit
+standaloneEnv RunnerI{..} f = f >>= go problem
+  where
+    -- generate a transcript for the unit
+    go p file = do pwd <- getCurrentDirectory
+                   let fPath = mconcat [pwd,"/",file]
+                   _ <- run config{U.transcript = Just fPath} p >> return ()
+                   return (config,fPath)
+
+-- | Cleanup the environment created by criterion by removing the transcript
+-- file used to run the standalone solver
+standaloneCleanup :: BenchUnit -> IO ()
+standaloneCleanup (_,fPath) =  P.callCommand $ "rm " ++ fPath
+
+-- | To construct a benchmark to test SBV's overhead we setup an environment
+-- with criterion where a symbolic computation is emitted to a transcript file.
+-- To test the solver without respect to SBV (standalone) we pass the transcript
+-- file to the solver using the same primitives SBV does. Not that mkFileName
+-- generates a random filename that is removed at the end of the benchmark. This
+-- function exposes the solver and the solve interface in case the user would
+-- like to benchmark with something other than 'Data.SBV.z3' and so that we can
+-- benchmark all solving variants, e.g., 'Data.SBV.proveWith',
+-- 'Data.SBV.satWith', 'Data.SBV.allProveWith' etc.
+mkOverheadBenchMark' :: RunnerI -> Benchmark
+mkOverheadBenchMark' r@RunnerI{..} =
+  envWithCleanup
+  (standaloneEnv r U.mkFileName)
+  standaloneCleanup $
+  \ ~unit ->
+    bgroup description [ bench "standalone" $ nfIO $ runStandaloneSolver unit
+                       -- notice for sbv benchmark; we pull the solver out of unit and
+                       -- use the input problem not the transcript in the unit
+                       , bench "sbv"        $ nfIO $ run (fst unit) problem
+                       ]
+
+mkOverheadBenchMark :: Runner -> Benchmark
+mkOverheadBenchMark (Runner r@RunnerI{..}) = mkOverheadBenchMark' r
+mkOverheadBenchMark (RunnerGroup rs)       = bgroup "" $ -- leave the description close to the benchmark/problem definition
+                                             mkOverheadBenchMark <$> rs
+
+-- | This is just a wrapper around the RunnerI constructor and serves as the main
+-- entry point to make a runner for a user in case they need something custom.
+runner' :: (NFData b, Show b) =>
+  (forall a. U.Provable a => U.SMTConfig -> a -> IO b)
+  -> U.SMTConfig
+  -> String
+  -> Problem
+  -> Runner
+runner' r config description problem = Runner $ RunnerI{..}
+  where run = toRun r
+
+-- | Convenience function for creating benchmarks that exposes a configuration
+runnerWith :: U.Provable a => U.SMTConfig -> String -> a -> Runner
+runnerWith c d p = runner' U.satWith c d (Problem p)
+
+-- | Main entry point for simple benchmarks. See 'mkRunner'' or 'mkRunnerWith'
+-- for versions of this function that allows custom inputs. If you have some use
+-- case that is not considered then you can simply overload the record fields.
+runner :: U.Provable a => String -> a -> Runner
+runner d p = runnerWith U.z3 d p `using` setRunner U.satWith
+
+-- | create a runner group. Useful for benchmarks that need to run several
+-- benchmarks. See 'BenchSuite.Puzzles.NQueens' for an example.
+rGroup :: [Runner] -> Runner
+rGroup = RunnerGroup
+
+-- | Orphaned instances just for benchmarking
+instance NFData U.AllSatResult where
+  rnf (U.AllSatResult (a, b, c, results)) =
+    rnf a `seq` rnf b `seq` rnf c `seq` rwhnf results
+
+-- | Unwrap the existential type to make criterion happy
+instance NFData BenchResult where rnf (BenchResult a) = rnf a

--- a/SBVBenchSuite/BenchSuite/Puzzles/Birthday.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Birthday.hs
@@ -1,0 +1,25 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Birthday
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Birthday
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Birthday(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.Birthday
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Birthday" puzzle `using` setRunner allSatWith

--- a/SBVBenchSuite/BenchSuite/Puzzles/Coins.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Coins.hs
@@ -1,0 +1,35 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Coins
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Coins
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Coins(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.Coins
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Coins" coinsPgm
+  where coinsPgm = do cs <- mapM mkCoin [1..6]
+                      mapM_ constrain [c s | s <- combinations cs, length s >= 2, c <- [c1, c2, c3, c4, c5, c6]]
+                      constrain $ sAnd $ zipWith (.>=) cs (tail cs)
+                      -- normally we would call output here, but returning
+                      -- several outputs from a symbolic computation doesn't
+                      -- play nice with either the transcript generation or the benchmarking apparantly
+
+                      -- output $ sum cs .== 115
+
+                      return $ sum cs .== 115

--- a/SBVBenchSuite/BenchSuite/Puzzles/Counts.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Counts.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Counts
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Counts
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Counts(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.Counts
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Counts" countPgm `using` setRunner allSatWith
+ where countPgm = forAll_ puzzle' >>= return -- avoiding 'output' here again
+       puzzle' d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 = puzzle [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9]

--- a/SBVBenchSuite/BenchSuite/Puzzles/DogCatMouse.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/DogCatMouse.hs
@@ -1,0 +1,30 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.DogCatMouse
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.DogCatMouse
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.DogCatMouse(benchmarks) where
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "DogCatMouse" p `using` setRunner allSatWith
+  where p = do [dog, cat, mouse] <- sIntegers ["dog", "cat", "mouse"]
+               solve [ dog   .>= 1                                   -- at least one dog
+                     , cat   .>= 1                                   -- at least one cat
+                     , mouse .>= 1                                   -- at least one mouse
+                     , dog + cat + mouse .== 100                     -- buy precisely 100 animals
+                     , 1500 * dog + 100 * cat + 25 * mouse .== 10000 -- spend exactly 100 dollars (use cents since we don't have fractions)
+                     ]

--- a/SBVBenchSuite/BenchSuite/Puzzles/Euler185.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Euler185.hs
@@ -1,0 +1,25 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Euler185
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Euler185
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Euler185(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.Euler185
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Euler185" euler185 `using` setRunner allSatWith

--- a/SBVBenchSuite/BenchSuite/Puzzles/Garden.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Garden.hs
@@ -1,0 +1,28 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Garden
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Garden
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Garden(benchmarks) where
+
+import Data.List (isSuffixOf)
+
+import Documentation.SBV.Examples.Puzzles.Garden
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner 
+benchmarks = runnerWith s "Garden" puzzle `using` setRunner allSatWith
+  where s = z3{satTrackUFs = False, isNonModelVar = ("_modelIgnore" `isSuffixOf`)}

--- a/SBVBenchSuite/BenchSuite/Puzzles/LadyAndTigers.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/LadyAndTigers.hs
@@ -1,0 +1,46 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.LadyAndTigers
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.LadyAndTigers
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.LadyAndTigers(benchmarks) where
+
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Puzzles.LadyAndTigers" p `using` setRunner allSatWith
+  where p = do
+
+          -- One boolean for each of the correctness of the signs
+          [sign1, sign2, sign3] <- mapM sBool ["sign1", "sign2", "sign3"]
+
+          -- One boolean for each of the presence of the tigers
+          [tiger1, tiger2, tiger3] <- mapM sBool ["tiger1", "tiger2", "tiger3"]
+
+          -- Room 1 sign: A Tiger is in this room
+          constrain $ sign1 .<=> tiger1
+
+          -- Room 2 sign: A Lady is in this room
+          constrain $ sign2 .<=> sNot tiger2
+
+          -- Room 3 sign: A Tiger is in room 2
+          constrain $ sign3 .<=> tiger2
+
+          -- At most one sign is true
+          constrain $ [sign1, sign2, sign3] `pbAtMost` 1
+
+          -- There are precisely two tigers
+          constrain $ [tiger1, tiger2, tiger3] `pbExactly` 2

--- a/SBVBenchSuite/BenchSuite/Puzzles/MagicSquare.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/MagicSquare.hs
@@ -1,0 +1,31 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.MagicSquare
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.MagicSquare
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.MagicSquare(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.MagicSquare
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ runner "MagicSquare.magic 2" (mkMagic 2) `using` setRunner allSatWith
+  , runner "MagicSquare.magic 3" (mkMagic 3) `using` setRunner allSatWith
+  ]
+
+mkMagic :: Int -> Symbolic SBool
+mkMagic n = (isMagic . chunk n) `fmap` mkExistVars (n*n)

--- a/SBVBenchSuite/BenchSuite/Puzzles/NQueens.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/NQueens.hs
@@ -1,0 +1,37 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.NQueens
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.NQueens
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.NQueens(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.NQueens
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ runner "NQueens.NQueens 1" (mkQueens 1) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 2" (mkQueens 2) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 3" (mkQueens 3) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 4" (mkQueens 4) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 5" (mkQueens 5) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 6" (mkQueens 6) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 7" (mkQueens 7) `using` setRunner allSatWith
+  , runner "NQueens.NQueens 8" (mkQueens 8) `using` setRunner allSatWith
+  ]
+
+mkQueens :: Int -> Symbolic SBool
+mkQueens n = isValid n `fmap` mkExistVars n

--- a/SBVBenchSuite/BenchSuite/Puzzles/SendMoreMoney.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/SendMoreMoney.hs
@@ -1,0 +1,35 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.SendMoreMoney
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.SendMoreMoney
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.SendMoreMoney(benchmarks) where
+
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = runner "Puzzles.SendMoreMoney" p `using` setRunner allSatWith
+  where p = do
+          ds@[s,e,n,d,m,o,r,y] <- mapM sInteger ["s", "e", "n", "d", "m", "o", "r", "y"]
+          let isDigit x = x .>= 0 .&& x .<= 9
+              val xs    = sum $ zipWith (*) (reverse xs) (iterate (*10) 1)
+              send      = val [s,e,n,d]
+              more      = val [m,o,r,e]
+              money     = val [m,o,n,e,y]
+          constrain $ sAll isDigit ds
+          constrain $ distinct ds
+          constrain $ s ./= 0 .&& m ./= 0
+          solve [send + more .== money]

--- a/SBVBenchSuite/BenchSuite/Puzzles/Sudoku.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Sudoku.hs
@@ -1,0 +1,34 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.Sudoku
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.Sudoku
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.Sudoku(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.Sudoku
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+    [ runner ("sudoku " ++ show n) (checkPuzzle s) `using` setRunner allSatWith
+       | (n, s) <-
+           zip
+             [(0::Int)..]
+             [puzzle0, puzzle1, puzzle2, puzzle3, puzzle4, puzzle5, puzzle6] ]
+
+
+checkPuzzle :: Puzzle -> Symbolic SBool
+checkPuzzle (i, f) = (valid . f) `fmap` mkExistVars i

--- a/SBVBenchSuite/BenchSuite/Puzzles/U2Bridge.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/U2Bridge.hs
@@ -1,0 +1,34 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Puzzles.U2Bridge
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Puzzles.U2Bridge
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Puzzles.U2Bridge(benchmarks) where
+
+import Documentation.SBV.Examples.Puzzles.U2Bridge
+
+import Utils.SBVBenchFramework
+import BenchSuite.Overhead.SBVOverhead
+
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ runner "U2Bridge_cnt1" (count 1) `using` setRunner allSatWith
+  , runner "U2Bridge_cnt2" (count 2) `using` setRunner allSatWith
+  , runner "U2Bridge_cnt3" (count 3) `using` setRunner allSatWith
+  , runner "U2Bridge_cnt4" (count 4) `using` setRunner allSatWith
+  , runner "U2Bridge_cnt6" (count 6) `using` setRunner allSatWith
+  ]
+  where
+    act     = do b <- exists_; p1 <- exists_; p2 <- exists_; return (b, p1, p2)
+    count n = isValid `fmap` mapM (const act) [1..(n::Int)]

--- a/SBVBenchSuite/SBVBench.hs
+++ b/SBVBenchSuite/SBVBench.hs
@@ -1,0 +1,71 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : SBVBench
+-- Copyright : (c) Jeffrey Young
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Main entry point to the bench suite.
+-----------------------------------------------------------------------------
+
+module Main where
+
+import           Criterion.Main
+import           Criterion.Types                  (Config (..))
+
+import           Utils.SBVBenchFramework
+
+import           BenchSuite.Overhead.SBVOverhead
+
+import qualified BenchSuite.Puzzles.Birthday
+import qualified BenchSuite.Puzzles.Coins
+import qualified BenchSuite.Puzzles.Counts
+import qualified BenchSuite.Puzzles.DogCatMouse
+import qualified BenchSuite.Puzzles.Euler185
+import qualified BenchSuite.Puzzles.Garden
+import qualified BenchSuite.Puzzles.LadyAndTigers
+import qualified BenchSuite.Puzzles.MagicSquare
+import qualified BenchSuite.Puzzles.NQueens
+import qualified BenchSuite.Puzzles.SendMoreMoney
+import qualified BenchSuite.Puzzles.Sudoku
+import qualified BenchSuite.Puzzles.U2Bridge
+
+-- | Custom config to limit benchmarks to 5 minutes of runtime. This is required
+-- because we can easily generate benchmarks that take a lot of wall time to
+-- solve, especially with 'Data.SBV.allSatWith' calls
+benchConfig :: Config
+benchConfig = defaultConfig {timeLimit = 300.00}
+
+-- The bench harness
+main :: IO ()
+main = defaultMainWith benchConfig $
+       [ puzzles
+       ]
+
+-- | Benchmarks for 'Documentation.SBV.Examples.Puzzles'. Each benchmark file
+-- defines a 'benchmarks' function which returns a
+-- 'BenchSuite.Overhead.SBVOverhead.Runner'. We want to allow benchmarks to be
+-- defined as closely as possible to the problems being solver. But for
+-- practical reasons we may desire to prevent benchmarking 'Data.SBV.allSat'
+-- calls because they could timeout. Thus by using
+-- 'BenchSuite.Overhead.SBVOverhead.Runner' we can define the benchmark
+-- mirroring the logic of the symbolic program. But that might be expensive to
+-- benchmark, so using this method we can change solver details _without_
+-- redefining the benchmark, as I have done below by converting all examples to
+-- use 'Data.SBV.satWith'.
+puzzles :: Benchmark
+puzzles = bgroup "Puzzles" $ (mkOverheadBenchMark . setRunner satWith) <$>
+          [ BenchSuite.Puzzles.Coins.benchmarks
+          , BenchSuite.Puzzles.Counts.benchmarks
+          , BenchSuite.Puzzles.Birthday.benchmarks
+          , BenchSuite.Puzzles.DogCatMouse.benchmarks
+          , BenchSuite.Puzzles.Euler185.benchmarks
+          , BenchSuite.Puzzles.Garden.benchmarks
+          , BenchSuite.Puzzles.LadyAndTigers.benchmarks
+          , BenchSuite.Puzzles.SendMoreMoney.benchmarks
+          , BenchSuite.Puzzles.NQueens.benchmarks
+          , BenchSuite.Puzzles.MagicSquare.benchmarks
+          , BenchSuite.Puzzles.Sudoku.benchmarks
+          , BenchSuite.Puzzles.U2Bridge.benchmarks
+          ]

--- a/SBVBenchSuite/Utils/SBVBenchFramework.hs
+++ b/SBVBenchSuite/Utils/SBVBenchFramework.hs
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : Utils.SBVTestFramework
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Various goodies for benchmarking SBV
+-----------------------------------------------------------------------------
+
+module Utils.SBVBenchFramework
+  ( mkExecString
+  , mkFileName
+  , module Criterion.Main
+  , module Data.SBV
+  ) where
+
+import qualified Data.List      as L
+import           System.Process (showCommandForUser)
+import           System.Random
+
+import           Criterion.Main (Benchmark, bgroup)
+
+import           Data.SBV
+
+-- | make the string to call executable from the command line. All the heavy
+-- lifting is done by 'System.Process.showCommandForUser', the rest is just
+-- projections out of 'Data.SBV.SMTConfig'
+mkExecString :: SMTConfig -> FilePath -> String
+mkExecString config inputFile = showCommandForUser exec $ inputFile:opts
+  where smtSolver = solver config
+        exec      = executable smtSolver
+        opts'     = options smtSolver config
+        opts      = L.delete "-in" opts' -- remove opt for interactive mode so
+                                         -- that this plays nice with
+                                         -- criterion environments
+
+-- | simple wrapper to create random file names.
+mkFileName :: IO String
+mkFileName = do gen <- newStdGen
+                return . take 32 $ randomRs ('a','z') gen

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -389,3 +389,41 @@ Test-Suite SBVHLint
     Other-modules   : Utils.SBVTestFramework
     main-is:          SBVHLint.hs
     type:             exitcode-stdio-1.0
+
+Benchmark SBVBench
+  type            : exitcode-stdio-1.0
+  default-language: Haskell2010
+  ghc-options     : -with-rtsopts=-K64m -O2
+  other-extensions: DataKinds
+                    DeriveAnyClass
+                    DeriveDataTypeable
+                    FlexibleContexts
+                    GeneralizedNewtypeDeriving
+                    OverloadedLists
+                    OverloadedStrings
+                    Rank2Types
+                    RankNTypes
+                    ScopedTypeVariables
+                    StandaloneDeriving
+                    TemplateHaskell
+                    TupleSections
+                    TypeApplications
+  Build-depends : base >= 4.11, filepath, syb, crackNum >= 2.3
+                , sbv, directory, random, mtl, containers
+                , criterion, process, deepseq
+  Hs-Source-Dirs  : SBVBenchSuite
+  main-is         : SBVBench.hs
+  Other-modules   : Utils.SBVBenchFramework
+                  , BenchSuite.Overhead.SBVOverhead
+                  , BenchSuite.Puzzles.Birthday
+                  , BenchSuite.Puzzles.Coins
+                  , BenchSuite.Puzzles.Counts
+                  , BenchSuite.Puzzles.DogCatMouse
+                  , BenchSuite.Puzzles.Euler185
+                  , BenchSuite.Puzzles.Garden
+                  , BenchSuite.Puzzles.LadyAndTigers
+                  , BenchSuite.Puzzles.MagicSquare
+                  , BenchSuite.Puzzles.NQueens
+                  , BenchSuite.Puzzles.SendMoreMoney
+                  , BenchSuite.Puzzles.Sudoku
+                  , BenchSuite.Puzzles.U2Bridge


### PR DESCRIPTION
### What
Pull request for phase 1 sbv benchmarks as discussed in #484. This adds basic benchmarking utility to `sbv` using `criterion`. This doesn't add any new dependencies and provides an api for creating new benchmarks, see `BenchSuite.Puzzles` for examples.

### How
Run with `cabal bench`:
```
$ cabal bench
benchmarking Puzzles/Coins/standalone
time                 179.8 ms   (168.0 ms .. 193.0 ms)
                     0.977 R²   (0.964 R² .. 0.997 R²)
mean                 171.8 ms   (169.6 ms .. 175.9 ms)
std dev              10.75 ms   (6.284 ms .. 17.10 ms)
variance introduced by outliers: 42% (moderately inflated)
...
```

or, if desired you can also output the results to a csv file with:
```
$ cabal build
$ ./dist/build/SBVBench/SBVBench --csv "test.csv"
$ cat test.csv 
Name,Mean,MeanLB,MeanUB,Stddev,StddevLB,StddevUB
Puzzles/Coins/standalone,0.1717946026770784,0.16961267840212116,0.17589632020186868,1.0745479995855869e-2,6.284256037335621e-3,1.7098143311250525e-2
```

### Design
I've chosen to keep the `overhead`  benchmarks but it is trivial to just run the `sbv` benchmark without the `standalone` one, see `Overhead.SBVOverhead.mkOverheadBenchmark` for details. The framework depends on `RankNTypes` and `ExistentialQuantification` to hide the type information for the problems to be solved and their return type. This is useful for a couple of reasons: first it keeps the benchmarks as close to the problem definition as possible while still allowing a user to operate on the benchmark later. For example, I define all of the puzzle benchmarks, many of which require `Data.SBV.allSatWith` for their problem definition, but then I change these to `Data.SBV.satWith` in `SBVBench.hs` because `Data.SBV.allSatWith` leads to a lot of variance and outliers in criterion. Secondly, it allows `SBVBench.hs`, the bench suite entry point, to use heterogeneous lists which keeps the interface with criterion clean.

Please review and get back to me. All comments and feedback welcome!

- Jeff