### PR TITLE
Correct an error message in Data.SBV.Core.Symbolic.registerLabel

### DIFF
--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -1143,7 +1143,7 @@ registerLabel whence st nm
   | '|' `elem` nm
   = err "contains the character `|', which is not allowed!"
   | '\\' `elem` nm
-  = err "contains the character `\', which is not allowed!"
+  = err "contains the character `\\', which is not allowed!"
   | True
   = do old <- readIORef $ rUsedLbls st
        if nm `Set.member` old


### PR DESCRIPTION
If the label contains the character `\`, the error message would read:

> contains the character `', which is not allowed!

While it should read

> contains the character `\', which is not allowed!