### PR TITLE
Export IsNonZero. Export WordN, SIntN From/ToSized in Data.SBV.Trans.

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -147,7 +147,7 @@ module Data.SBV (
   -- *** Signed bit-vectors
   , SInt8, SInt16, SInt32, SInt64, SInt, IntN
   -- *** Converting between fixed-size and arbitrary bitvectors
-  , FromSized, ToSized, fromSized, toSized
+  , IsNonZero, FromSized, ToSized, fromSized, toSized
   -- ** Unbounded integers
   -- $unboundedLimitations
   , SInteger

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -27,7 +27,7 @@ module Data.SBV.Trans (
   -- *** Signed bit-vectors
   , SInt8, SInt16, SInt32, SInt64, SInt, IntN
   -- *** Converting between fixed-size and arbitrary bitvectors
-  , IsNonZero(..) , FromSized, ToSized, fromSized, toSized
+  , IsNonZero, FromSized, ToSized, fromSized, toSized
   -- ** Unbounded integers
   , SInteger
   -- ** Floating point numbers

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -23,9 +23,11 @@ module Data.SBV.Trans (
   , sAnd, sOr, sAny, sAll
   -- ** Bit-vectors
   -- *** Unsigned bit-vectors
-  , SWord8, SWord16, SWord32, SWord64
+  , SWord8, SWord16, SWord32, SWord64, SWord, WordN
   -- *** Signed bit-vectors
-  , SInt8, SInt16, SInt32, SInt64
+  , SInt8, SInt16, SInt32, SInt64, SInt, IntN
+  -- *** Converting between fixed-size and arbitrary bitvectors
+  , IsNonZero(..) , FromSized, ToSized, fromSized, toSized
   -- ** Unbounded integers
   , SInteger
   -- ** Floating point numbers

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -165,6 +165,8 @@ import Data.SBV.Core.Symbolic
 import Data.SBV.Provers.Prover
 
 import Data.SBV.Client
+import Data.SBV.Client.BaseIO  (FromSized, ToSized, fromSized, toSized)
+
 
 import Data.SBV.Utils.TDiff   (Timing(..))
 


### PR DESCRIPTION
Adds / Fix 2 little module export related things:

1. Export ```IsNonZero``` type family from ```Data.SBV.Core.Sized```  from ```Data.SBV``` and ```Data.SBV.Trans```
2. Added the sized word/int types from ```Data.SBV.Core.Sized```  to the export list of ```Data.SBV.Trans```

I want to be able to use ```IsNonZero``` as a constraint in my user code. As ```Data.SBV.Core.Sized``` is defined as other module in cabal I could not access it, so reexported it through Data.SBV and Data.SBV.Trans. 

During fixing that I also noticed that the ```Data.SBV.Core.Sized``` things were not exported through Data.SBV.Trans.

