### PR TITLE
Improve scalability for very large numbers of uninterpreted functions

### DIFF
--- a/Data/SBV/Control/Utils.hs
+++ b/Data/SBV/Control/Utils.hs
@@ -1165,7 +1165,7 @@ checkSatUsing cmd = do let bad = unexpected "checkSat" cmd "one of sat/unsat/unk
 -- | What are the top level inputs? Trackers are returned as top level existentials
 getQuantifiedInputs :: (MonadIO m, MonadQuery m) => m [(Quantifier, NamedSymVar)]
 getQuantifiedInputs = do State{rinps} <- queryState
-                         (rQinps, rTrackers) <- liftIO $ readIORef rinps
+                         ((rQinps, rTrackers), _) <- liftIO $ readIORef rinps
 
                          let qinps    = reverse rQinps
                              trackers = map (EX,) $ reverse rTrackers
@@ -1610,7 +1610,7 @@ executeQuery queryContext (QueryT userQuery) = do
                     case queryContext of
                       QueryInternal -> return ()         -- we're good, internal usages don't mess with scopes
                       QueryExternal -> do
-                        (userInps, _) <- readIORef (rinps st)
+                        ((userInps, _), _) <- readIORef (rinps st)
                         let badInps = reverse [n | (ALL, (_, n)) <- userInps]
                         case badInps of
                           [] -> return ()

--- a/Data/SBV/SMT/SMTLib2.hs
+++ b/Data/SBV/SMT/SMTLib2.hs
@@ -304,7 +304,8 @@ cvt ctx kindInfo isSat comments (inputs, trackerVars) skolemInps consts tbls arr
         mkLet (s, SBVApp (Label m) [e]) = "(let ((" ++ show s ++ " " ++ cvtSV                skolemMap          e ++ ")) ; " ++ m
         mkLet (s, e)                    = "(let ((" ++ show s ++ " " ++ cvtExp solverCaps rm skolemMap tableMap e ++ "))"
 
-        userName s = case s `lookup` map snd inputs of
+        userNameMap = M.fromList (map snd inputs)
+        userName s = case M.lookup s userNameMap of
                         Just u  | show s /= u -> " ; tracks user variable " ++ show u
                         _ -> ""
 


### PR DESCRIPTION
These changes improve efficiency by avoiding O(n) operations like `elem` and `lookup` on lists. In one s2n-related proof script, where saw-script is generating thousands of uninterpreted function symbols, we were seeing `introduceUserName` and `cvt.userName` combine to take up 67% of the total runtime (on the order of several minutes). Switching from lists to maps and sets makes the runtime of these functions negligible.