### PR TITLE
adding support for concurrent queries see issue #500

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -255,6 +255,7 @@ module Data.SBV (
   , satWith, allSat, allSatWith, optimize, optimizeWith, isVacuous
   , isVacuousWith, isTheorem, isTheoremWith, isSatisfiable, isSatisfiableWith
   , proveWithAll, proveWithAny, satWithAll
+  , proveConcurrentWithAny, proveConcurrentWithAll, satConcurrentWithAny, satConcurrentWithAll
   , satWithAny, generateSMTBenchmark
   , solve
   -- * Constraints

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -81,6 +81,9 @@ module Data.SBV.Dynamic
   , safeWith
   -- * Proving properties using multiple solvers
   , proveWithAll, proveWithAny, satWithAll, satWithAny
+  -- * Proving properties using multiple threads
+  , proveConcurrentWithAll, proveConcurrentWithAny
+  , satConcurrentWithAny, satConcurrentWithAll
   -- * Quick-check
   , svQuickCheck
 
@@ -146,7 +149,10 @@ import Data.SBV.Provers.Prover (boolector, cvc4, yices, z3, mathSAT, abc, defaul
 import Data.SBV.SMT.SMT        (ThmResult(..), SatResult(..), SafeResult(..), OptimizeResult(..), AllSatResult(..), genParse)
 import Data.SBV                (sbvCheckSolverInstallation, defaultSolverConfig, sbvAvailableSolvers)
 
-import qualified Data.SBV                as SBV (SBool, proveWithAll, proveWithAny, satWithAll, satWithAny)
+import qualified Data.SBV                as SBV (SBool, proveWithAll, proveWithAny, satWithAll, satWithAny
+                                                , proveConcurrentWithAll, proveConcurrentWithAny
+                                                , satConcurrentWithAny, satConcurrentWithAll
+                                                )
 import qualified Data.SBV.Core.Data      as SBV (SBV(..))
 import qualified Data.SBV.Core.Model     as SBV (sbvQuickCheck)
 import qualified Data.SBV.Provers.Prover as SBV (proveWith, satWith, safeWith, allSatWith, generateSMTBenchmark)
@@ -194,6 +200,20 @@ proveWithAll cfgs s = SBV.proveWithAll cfgs (fmap toSBool s)
 proveWithAny :: [SMTConfig] -> Symbolic SVal -> IO (Solver, NominalDiffTime, ThmResult)
 proveWithAny cfgs s = SBV.proveWithAny cfgs (fmap toSBool s)
 
+-- | Prove a property with query mode using multiple threads. Each query
+-- computation will spawn a thread and a unique instance of your solver to run
+-- asynchronously. The Symbolic SVal is duplicated for each thread. This
+-- function will block until they all child threads return.
+proveConcurrentWithAll :: SMTConfig -> Symbolic SVal -> [Query SVal] -> IO [(Solver, NominalDiffTime, ThmResult)]
+proveConcurrentWithAll cfg s queries = SBV.proveConcurrentWithAll cfg queries (fmap toSBool s)
+
+-- | Prove a property with query mode using multiple threads. Each query
+-- computation will spawn a thread and a unique instance of your solver to run
+-- asynchronously. The Symbolic SVal is duplicated for each thread. This
+-- function will return the first query computation that completes.
+proveConcurrentWithAny :: SMTConfig -> Symbolic SVal -> [Query SVal] -> IO (Solver, NominalDiffTime, ThmResult)
+proveConcurrentWithAny cfg s queries = SBV.proveConcurrentWithAny cfg queries (fmap toSBool s)
+
 -- | Find a satisfying assignment to a property with multiple solvers,
 -- running them in separate threads. The results will be returned in
 -- the order produced.
@@ -205,6 +225,20 @@ satWithAll cfgs s = SBV.satWithAll cfgs (fmap toSBool s)
 -- to finish will be returned, remaining threads will be killed.
 satWithAny :: [SMTConfig] -> Symbolic SVal -> IO (Solver, NominalDiffTime, SatResult)
 satWithAny cfgs s = SBV.satWithAny cfgs (fmap toSBool s)
+
+-- | Find a satisfying assignment to a property with multiple threads in query
+-- mode. The Symbolic SVal represents what is known to all child query threads.
+-- Each query thread will spawn a unique instance of the solver. Only the first
+-- one to finish will be returned and the other threads will be killed.
+satConcurrentWithAny :: SMTConfig -> [Query b] -> Symbolic SVal -> IO (Solver, NominalDiffTime, SatResult)
+satConcurrentWithAny cfg qs s = SBV.satConcurrentWithAny cfg qs (fmap toSBool s)
+
+-- | Find a satisfying assignment to a property with multiple threads in query
+-- mode. The Symbolic Sval represents what is known to all child query threads.
+-- Each query thread will spawn a unique instance of the solver. This function
+-- will block until all child threads have completed
+satConcurrentWithAll :: SMTConfig -> [Query b] -> Symbolic SVal -> IO [(Solver, NominalDiffTime, SatResult)]
+satConcurrentWithAll cfg qs s = SBV.satConcurrentWithAll cfg qs (fmap toSBool s)
 
 -- | Extract a model, the result is a tuple where the first argument (if True)
 -- indicates whether the model was "probable". (i.e., if the solver returned unknown.)

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -85,6 +85,7 @@ module Data.SBV.Trans (
 
   -- * Properties, proofs, and satisfiability
   , Predicate, Goal, MProvable(..), Provable, proveWithAll, proveWithAny , satWithAll
+  , proveConcurrentWithAny, proveConcurrentWithAll, satConcurrentWithAny, satConcurrentWithAll
   , satWithAny, generateSMTBenchmark
   , solve
   -- * Constraints

--- a/Documentation/SBV/Examples/Queries/Concurrency.hs
+++ b/Documentation/SBV/Examples/Queries/Concurrency.hs
@@ -1,0 +1,171 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : Documentation.SBV.Examples.Queries.Concurrency
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- When we would like to solve a set of related problems we can use query mode
+-- to perform push's and pop's. However performing a push and a pop is still
+-- single threaded and so each solution will need to wait for the previous
+-- solution to be found. In this example we show a class of functions
+-- 'Data.SBV.satConcurrentAll' and 'Data.SBV.satConcurrentAny' which spin up
+-- independent solver instances and runs query computations concurrently. The
+-- children query computations are allowed to communicate with one another as
+-- demonstrated in the second demo
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module Documentation.SBV.Examples.Queries.Concurrency where
+
+import Data.SBV
+import Data.SBV.Control
+import Control.Concurrent
+import Control.Monad.IO.Class (liftIO)
+
+-- | Find all solutions to @x + y .== 10@ for positive @x@ and @y@, but at each
+-- iteration we would like to ensure that the value of @x@ we get is at least
+-- twice as large as the previous one. This is rather silly, but demonstrates
+-- how we can dynamically query the result and put in new constraints based on
+-- those.
+shared :: MVar (SInteger, SInteger) -> Symbolic ()
+shared v = do
+  x <- sInteger "x"
+  y <- sInteger "y"
+  constrain $ y .<= 10
+  constrain $ x .<= 10
+  constrain $ x + y .== 10
+  liftIO $ putMVar v (x,y)
+
+-- | in our first query we'll define a constraint that will not be known to the
+-- shared or second query and then solve for an answer that will differ from the
+-- first query. Note that we need to pass an MVar in so that we can operate on
+-- the shared variables. In general, the variables you want to operate on should
+-- be defined in the shared part of the query and then passed to the children
+-- queries via channels, MVars, or TVars. In this query we constrain x to be
+-- less than y and then return the sum of the values. We add a threadDelay just
+-- for demonstration purposes
+queryOne :: MVar (SInteger, SInteger) -> Query (Maybe Integer)
+queryOne v = do
+  io $ putStrLn $ "[One]: Waiting"
+  liftIO $ threadDelay 5000000
+  io $ putStrLn $ "[One]: Done"
+  (x,y) <- liftIO $ takeMVar v
+  constrain $ x .< y
+
+  cs <- checkSat
+  case cs of
+    Unk   -> error "Too bad, solver said unknown.." -- Won't happen
+    Unsat -> do io $ putStrLn "No other solution!"
+                return Nothing
+
+    Sat   -> do xv <- getValue x
+                yv <- getValue y
+                io $ putStrLn $ "[One]: Current solution is: " ++ show (xv, yv)
+                return $ Just (xv + yv)
+
+-- | In the second query we constrain for an answer where y is smaller than x,
+-- and then return the product of the found values
+queryTwo :: MVar (SInteger, SInteger) -> Query (Maybe Integer)
+queryTwo v = do
+  (x,y) <- liftIO $ takeMVar v
+  io $ putStrLn $ "[Two]: got values" ++ show (x,y)
+  constrain $ y .< x
+
+  cs <- checkSat
+  case cs of
+    Unk   -> error "Too bad, solver said unknown.." -- Won't happen
+    Unsat -> do io $ putStrLn "No other solution!"
+                return Nothing
+
+    Sat   -> do yv <- getValue y
+                xv <- getValue x
+                io $ putStrLn $ "[Two]: Current solution is: " ++ show (xv, yv)
+                return $ Just (xv * yv)
+
+-- | run the demo several times to see that the children threads will change
+-- ordering
+demo :: IO ()
+demo = do
+  v <- newEmptyMVar
+  putStrLn $ "[Main]: Hello from main, kicking off children: "
+  results <- satConcurrentWithAll z3 [queryOne v, queryTwo v] (shared v)
+  putStrLn $ "[Main]: Children spawned, waiting for results"
+  putStrLn $ "[Main]: Here they are: "
+  putStrLn $ show results
+
+
+sharedDependent :: MVar (SInteger, SInteger) -> Symbolic ()
+sharedDependent v = do -- constrain positive and sum:
+  x <- sInteger "x"
+  y <- sInteger "y"
+  constrain $ y .<= 10
+  constrain $ x .<= 10
+  constrain $ x + y .== 10
+  liftIO $ putMVar v (x,y)
+
+-- | In our first query we will make a constrain, solve the constraint and
+-- return the values for our variables, then we'll mutate the MVar sending
+-- information to the second query. Note that you could use channels, or TVars,
+-- or TMVars, whatever you need here, we just use MVars for demonstration
+-- purposes. Also note that this effectively creates an ordering between the
+-- children queries
+firstQuery :: MVar (SInteger, SInteger) -> MVar (SInteger , SInteger) -> Query (Maybe Integer)
+firstQuery v1 v2 = do
+  (x,y) <- liftIO $ takeMVar v1
+  io $ putStrLn $ "[One]: got vars...working..."
+  constrain $ x .< y
+
+  cs <- checkSat
+  case cs of
+    Unk   -> error "Too bad, solver said unknown.." -- Won't happen
+    Unsat -> do io $ putStrLn "No other solution!"
+                return Nothing
+
+    Sat   -> do xv <- getValue x
+                yv <- getValue y
+                io $ putStrLn $ "[One]: Current solution is: " ++ show (xv, yv)
+                io $ putStrLn $ "[One]: Place vars for [Two]"
+                liftIO $ putMVar v2 (literal (xv + yv), literal (xv * yv))
+                return $ Just (xv + yv)
+
+-- | In the second query we create a new variable z, and then a symbolic query
+-- using information from the first query and return a solution that uses the
+-- new variable and the old variables. Each child query is run in a separate
+-- instance of z3 so you can think of this query as driving to a point in the
+-- search space, then waiting for more information, once it gets that
+-- information it will run a completely separate computation from the first one
+-- and return its results.
+secondQuery :: MVar (SInteger, SInteger) -> Query (Maybe Integer)
+secondQuery v2 = do
+  (x,y) <- liftIO $ takeMVar v2
+  io $ putStrLn $ "[Two]: got values" ++ show (x,y)
+  z <- freshVar "z"
+  constrain $ z .> x + y
+
+  cs <- checkSat
+  case cs of
+    Unk   -> error "Too bad, solver said unknown.." -- Won't happen
+    Unsat -> do io $ putStrLn "No other solution!"
+                return Nothing
+
+    Sat   -> do yv <- getValue y
+                xv <- getValue x
+                zv <- getValue z
+                io $ putStrLn $ "[Two]: My solution is: " ++ show (zv + xv, zv + yv)
+                return $ Just (zv * xv * yv)
+
+-- | in our second demonstration we show how through the use of concurrency
+-- constructs the user can have children queries communicate with one another.
+-- Note that the children queries are independent and so anything side-effectual
+-- like a push or a pop will be isolated to that child thread, unless of course
+-- it happens in shared.
+demoDependent :: IO ()
+demoDependent = do
+  v1 <- newEmptyMVar
+  v2 <- newEmptyMVar
+  results <- satConcurrentWithAll z3 [firstQuery v1 v2, secondQuery v2] (sharedDependent v1)
+  print results


### PR DESCRIPTION
Hey Levent,

I haven't added documentation for these new functions in `Data.SBV` yet becase I wanted your review/input first. I think I've hit a sweet spot in the API that we discussed for these end points where a user is able to define what is shared for each sub-query, each sub-query, and then can choose to run these waiting for all results or any results much like `satAll` and `satAny`. 

Most of the code is in `Data.SBV.Provers.Prover` and I wanted to point out the large amount of repetition in these functions. I'm not opposed to DRY'ing it out with some helper functions if you want to keep the code base more tidy than this. I'm also open for more descriptive naming, I don't feel as though `satConcurrentWithAny` is particularly descriptive of what is actually being delivered, which is something more like `run-related-queries-concurrently`.

Lastly I used `mapConcurrently` from `async` because `async` was already a dependency. For whatever reason, the mapping function you have for `sbvWithAll/Any` didn't actually give me concurrent behavior (specifically `queryOne` in the `demo` would always finish before `queryTwo`). Might be something, might be nothing, I just wanted to point it out.

Please let me know your thoughts, I'll make whatever changes and revise the PR.

- Jeff