### PR TITLE
Remove ghc dependency

### DIFF
--- a/sbv.cabal
+++ b/sbv.cabal
@@ -72,7 +72,7 @@ Library
                     ViewPatterns
   Build-Depends   : base >= 4.11 && < 5
                   , crackNum >= 2.3
-                  , ghc, QuickCheck, template-haskell
+                  , QuickCheck, template-haskell
                   , array, async, containers, deepseq, directory, filepath, time
                   , pretty, process, mtl, random, syb, transformers
                   , generic-deriving


### PR DESCRIPTION
The `ghc` dependency has become redundant some time ago, removing it shouldn't break builds. Additionally, this enables `sbv` to be built by Asterius.