### PR TITLE
Criterion -> Gauge, Reworked Benchmark Api, adding BitPrecise and Query Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist-newstyle/
 .ghc.environment.*
 .*.swp
 .brokdb
+*.o
+*.hi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@
     get in touch if you used this class in some cunning way and you
     need its functionality back.
 
+  * Reworked SBVBenchSuite api, added "BenchSuite.BitPrecise" and
+    "BenchSuite.Queries".
+
 ### Version 8.6, 2020-02-08
 
   * Fix typo in error message. Thanks to Oliver Charles
@@ -362,7 +365,7 @@
     then your float value will be minimized as the corresponding 32 (or 64 for
     doubles) bit word. Note that this methods supports infinities properly, and
     does not distinguish between -0 and +0.
-    
+
   * Optimization routines have been generalized to work over arbitrary metric-spaces,
     with user-definable mappings. The simplest instance we have added is optimization
     over booleans, by the obvious numeric mapping. Tuples are also supported with

--- a/SBVBenchSuite/BenchSuite/Bench/Bench.hs
+++ b/SBVBenchSuite/BenchSuite/Bench/Bench.hs
@@ -1,7 +1,8 @@
 -----------------------------------------------------------------------------
 -- |
--- Module    : BenchSuite.Batch.SBVOverhead
+-- Module    : BenchSuite.Bench.Bench
 -- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
 -- License   : BSD3
 -- Maintainer: erkokl@gmail.com
 -- Stability : experimental
@@ -19,15 +20,18 @@
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
-module BenchSuite.Overhead.SBVOverhead
-  ( runner
-  , runner'
-  , runnerWith
+module BenchSuite.Bench.Bench
+  ( run
+  , run'
+  , runWith
+  , runIOWith
+  , runIO
   , rGroup
-  , mkOverheadBenchMark
+  , runOverheadBenchMark
+  , runBenchMark
   , onConfig
   , onDesc
-  , setRunner
+  , runner
   , onProblem
   , Runner(..)
   , using
@@ -36,14 +40,15 @@ module BenchSuite.Overhead.SBVOverhead
 import           Control.DeepSeq         (NFData (..), rwhnf)
 import           System.Directory        (getCurrentDirectory)
 import           System.IO
+import           System.IO.Silently      (silence)
 
-import           Criterion.Main
+import           Gauge.Main
 
 import qualified System.Process          as P
 import qualified Utils.SBVBenchFramework as U
 
 -- | The type of the problem to benchmark. This allows us to operate on Runners
--- as values themselves yet still have a unified interface with criterion.
+-- as values themselves yet still have a unified interface with gauge.
 data Problem = forall a . U.Provable a => Problem a
 
 -- | Similarly to Problem, BenchResult is boilerplate for a nice api
@@ -55,7 +60,7 @@ type BenchUnit = (U.SMTConfig, FilePath)
 
 -- | A runner is anything that allows the solver to solve, such as:
 -- 'Data.SBV.proveWith' or 'Data.SBV.satWith'. We utilize existential types to
--- lose type information and create a unified interface with criterion. We
+-- lose type information and create a unified interface with gauge. We
 -- require a runner in order to generate a 'Data.SBV.transcript' and then to run
 -- the actual benchmark. We bundle this redundantly into a record so that the
 -- benchmarks can be defined in each respective module, with the run function
@@ -63,27 +68,30 @@ type BenchUnit = (U.SMTConfig, FilePath)
 -- useful because problems that require 'Data.SBV.allSatWith' can lead to a lot
 -- of variance in the benchmarking data. Single benchmark runners like
 -- 'Data.SBV.satWith' and 'Data.SBV.proveWith' work best.
-data RunnerI = RunnerI { run         :: (U.SMTConfig -> Problem -> IO BenchResult)
+data RunnerI = RunnerI { runI        :: (U.SMTConfig -> Problem -> IO BenchResult)
                        , config      :: U.SMTConfig
                        , description :: String
                        , problem     :: Problem
-}
+                       }
 
 -- | GADT to allow arbritrary nesting of runners. This copies criterion's design
 -- so that we don't have to separate out runners that run a single benchmark
 -- from runners that need to run several benchmarks
 data Runner where
-  Runner :: RunnerI -> Runner           -- ^ a single run
-  RunnerGroup :: [Runner] -> Runner     -- ^ a group of runs
+  RBenchmark  :: Benchmark -> Runner    -- ^ a wrapper around gauge benchmarks
+  Runner      :: RunnerI   -> Runner    -- ^ a single run
+  RunnerGroup :: [Runner]  -> Runner    -- ^ a group of runs
 
 -- | Convenience boilerplate functions, simply avoiding a lens dependency
 using :: Runner -> (Runner -> Runner) -> Runner
 using = flip ($)
 
-setRunner :: (Show c, NFData c) =>
+-- | Set the runner function
+runner :: (Show c, NFData c) =>
   (forall a. U.Provable a => U.SMTConfig -> a -> IO c) -> Runner -> Runner
-setRunner r' (Runner r@RunnerI{..}) = Runner $ r{run = toRun r'}
-setRunner r' (RunnerGroup rs)       = RunnerGroup $ setRunner r' <$> rs
+runner r' (Runner r@RunnerI{..}) = Runner $ r{runI = toRun r'}
+runner r' (RunnerGroup rs)       = RunnerGroup $ runner r' <$> rs
+runner _  x                      = x
 
 toRun :: (Show c, NFData c) =>
   (forall a. U.Provable a => U.SMTConfig -> a -> IO c)
@@ -91,7 +99,7 @@ toRun :: (Show c, NFData c) =>
   -> Problem
   -> IO BenchResult
 toRun f c p = BenchResult <$> helper p
-  -- simpler to helper in onProblem, this is lmap from profunctor land, i.e., we
+  -- similar to helper in onProblem, this is lmap from profunctor land, i.e., we
   -- curry with a config, then change the runner function from (a -> IO c), to
   -- (Problem -> IO c)
   where helper (Problem a) = f c a
@@ -132,23 +140,23 @@ runStandaloneSolver (slvr, fname) =
   where command = U.mkExecString slvr fname
 
 -- | Given a file name, a solver config, and a problem to solve, create an
--- environment for the criterion benchmark by generating a transcript file
+-- environment for the gauge benchmark by generating a transcript file
 standaloneEnv :: RunnerI -> IO FilePath -> IO BenchUnit
 standaloneEnv RunnerI{..} f = f >>= go problem
   where
     -- generate a transcript for the unit
     go p file = do pwd <- getCurrentDirectory
                    let fPath = mconcat [pwd,"/",file]
-                   _ <- run config{U.transcript = Just fPath} p >> return ()
+                   _ <- runI config{U.transcript = Just fPath} p >> return ()
                    return (config,fPath)
 
--- | Cleanup the environment created by criterion by removing the transcript
--- file used to run the standalone solver
+-- | Cleanup the environment created by gauge by removing the transcript file
+-- used to run the standalone solver
 standaloneCleanup :: BenchUnit -> IO ()
 standaloneCleanup (_,fPath) =  P.callCommand $ "rm " ++ fPath
 
 -- | To construct a benchmark to test SBV's overhead we setup an environment
--- with criterion where a symbolic computation is emitted to a transcript file.
+-- with gauge where a symbolic computation is emitted to a transcript file.
 -- To test the solver without respect to SBV (standalone) we pass the transcript
 -- file to the solver using the same primitives SBV does. Not that mkFileName
 -- generates a random filename that is removed at the end of the benchmark. This
@@ -165,34 +173,59 @@ mkOverheadBenchMark' r@RunnerI{..} =
     bgroup description [ bench "standalone" $ nfIO $ runStandaloneSolver unit
                        -- notice for sbv benchmark; we pull the solver out of unit and
                        -- use the input problem not the transcript in the unit
-                       , bench "sbv"        $ nfIO $ run (fst unit) problem
+                       , bench "sbv"        $ nfIO $ runI (fst unit) problem
                        ]
 
-mkOverheadBenchMark :: Runner -> Benchmark
-mkOverheadBenchMark (Runner r@RunnerI{..}) = mkOverheadBenchMark' r
-mkOverheadBenchMark (RunnerGroup rs)       = bgroup "" $ -- leave the description close to the benchmark/problem definition
-                                             mkOverheadBenchMark <$> rs
+runOverheadBenchMark :: Runner -> Benchmark
+runOverheadBenchMark (Runner r@RunnerI{..}) = mkOverheadBenchMark' r
+runOverheadBenchMark (RunnerGroup rs)       = bgroup "" $ -- leave the description close to the benchmark/problem definition
+                                             runOverheadBenchMark <$> rs
+runOverheadBenchMark (RBenchmark b)         = b
+
+
+-- | make a normal benchmark without the overhead comparision. Notice this is
+-- just unpacking the Runner record
+mkBenchMark :: RunnerI -> Benchmark
+mkBenchMark RunnerI{..} = bgroup description [bench "sbv" . nfIO $! runI config problem]
+
+-- | Convert a Runner or a group of Runners to Benchmarks, this is an api level
+-- function to convert the runners defined in each file to benchmarks which can
+-- be run by gauge
+runBenchMark :: Runner -> Benchmark
+runBenchMark (Runner r@RunnerI{..}) = mkBenchMark r
+runBenchMark (RunnerGroup rs)       = bgroup "" $ runBenchMark <$> rs
+runBenchMark (RBenchmark b)         = b
 
 -- | This is just a wrapper around the RunnerI constructor and serves as the main
 -- entry point to make a runner for a user in case they need something custom.
-runner' :: (NFData b, Show b) =>
+run' :: (NFData b, Show b) =>
   (forall a. U.Provable a => U.SMTConfig -> a -> IO b)
   -> U.SMTConfig
   -> String
   -> Problem
   -> Runner
-runner' r config description problem = Runner $ RunnerI{..}
-  where run = toRun r
+run' r config description problem = Runner $ RunnerI{..}
+  where runI = toRun r
 
 -- | Convenience function for creating benchmarks that exposes a configuration
-runnerWith :: U.Provable a => U.SMTConfig -> String -> a -> Runner
-runnerWith c d p = runner' U.satWith c d (Problem p)
+runWith :: U.Provable a => U.SMTConfig -> String -> a -> Runner
+runWith c d p = run' U.satWith c d (Problem p)
 
 -- | Main entry point for simple benchmarks. See 'mkRunner'' or 'mkRunnerWith'
 -- for versions of this function that allows custom inputs. If you have some use
 -- case that is not considered then you can simply overload the record fields.
-runner :: U.Provable a => String -> a -> Runner
-runner d p = runnerWith U.z3 d p `using` setRunner U.satWith
+run :: U.Provable a => String -> a -> Runner
+run d p = runWith U.z3 d p `using` runner U.satWith
+
+-- | Entry point for problems that return IO or to benchmark IO results
+runIOWith :: NFData a => (a -> Benchmarkable) -> String -> a -> Runner
+runIOWith f d = RBenchmark . bench d . f
+
+-- | Benchmark an IO result of sbv, this could be codegen, return models, etc..
+-- See @runIOWith@ for a version which allows the consumer to select the
+-- Benchmarkable injection function
+runIO :: NFData a => String -> IO a -> Runner
+runIO d = RBenchmark . bench d . nfIO . silence
 
 -- | create a runner group. Useful for benchmarks that need to run several
 -- benchmarks. See 'BenchSuite.Puzzles.NQueens' for an example.
@@ -204,5 +237,5 @@ instance NFData U.AllSatResult where
   rnf (U.AllSatResult (a, b, c, results)) =
     rnf a `seq` rnf b `seq` rnf c `seq` rwhnf results
 
--- | Unwrap the existential type to make criterion happy
+-- | Unwrap the existential type to make gauge happy
 instance NFData BenchResult where rnf (BenchResult a) = rnf a

--- a/SBVBenchSuite/BenchSuite/BitPrecise/BitTricks.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/BitTricks.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.BitTricks
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.BitTricks
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.BitTricks(benchmarks) where
+
+import Documentation.SBV.Examples.BitPrecise.BitTricks
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV (proveWith)
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.run "Fast-min" fastMinCorrect `using` runner proveWith
+  , B.run  "Fast-max" fastMaxCorrect `using` runner proveWith
+  ]

--- a/SBVBenchSuite/BenchSuite/BitPrecise/BrokenSearch.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/BrokenSearch.hs
@@ -1,0 +1,42 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.BrokenSearch
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.BrokenSearch
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.BrokenSearch(benchmarks) where
+
+import Documentation.SBV.Examples.BitPrecise.BrokenSearch
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV (proveWith,sInt32,(.>=),(.<=),(.==),sFromIntegral,SInt64,sDiv,constrain)
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.run  "Arith.MidPointFixed"  (checkCorrect midPointFixed)      `using` runner Data.SBV.proveWith
+  , B.run  "Arith-Overflow"       (checkCorrect midPointAlternative)  `using` runner Data.SBV.proveWith
+  ]
+
+  where checkCorrect f = do low  <- sInt32 "low"
+                            high <- sInt32 "high"
+
+                            constrain $ low .>= 0
+                            constrain $ low .<= high
+
+                            let low', high' :: SInt64
+                                low'  = sFromIntegral low
+                                high' = sFromIntegral high
+                                mid'  = (low' + high') `sDiv` 2
+
+                                mid   = f low high
+
+                            return $ sFromIntegral mid .== mid'

--- a/SBVBenchSuite/BenchSuite/BitPrecise/Legato.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/Legato.hs
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.Legato
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.Legato
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.Legato(benchmarks) where
+
+import Documentation.SBV.Examples.BitPrecise.Legato
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.run    "Correctness.Legato" correctnessThm `using` runner Data.SBV.proveWith
+  , B.runIO  "CodeGen.Legato" legatoInC
+  ]
+  where correctnessThm = do
+          lo <- sWord "lo"
+
+          x <- sWord  "x"
+          y <- sWord  "y"
+
+          regX  <- sWord "regX"
+          regA  <- sWord "regA"
+
+          flagC <- sBool "flagC"
+          flagZ <- sBool "flagZ"
+
+          return $ legatoIsCorrect (x, y, lo, regX, regA, flagC, flagZ)

--- a/SBVBenchSuite/BenchSuite/BitPrecise/MergeSort.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/MergeSort.hs
@@ -1,0 +1,34 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.MergeSort
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.MergeSort
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.MergeSort(benchmarks) where
+
+import Documentation.SBV.Examples.BitPrecise.MergeSort
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.run    "Correctness.MergeSort 10"   (correctness' 10)   `using` runner Data.SBV.proveWith
+  , B.run    "Correctness.MergeSort 100"  (correctness' 100)  `using` runner Data.SBV.proveWith
+  , B.run    "Correctness.MergeSort 1000" (correctness' 1000) `using` runner Data.SBV.proveWith
+  , B.runIO  "CodeGen.MergeSort 10" $ codeGen 10
+  , B.runIO  "CodeGen.MergeSort 100" $ codeGen 100
+  , B.runIO  "CodeGen.MergeSort 1000" $ codeGen 1000
+  ]
+  where correctness' n = do xs <- mkFreeVars n
+                            let ys = mergeSort xs
+                            return $ nonDecreasing ys .&& isPermutationOf xs ys

--- a/SBVBenchSuite/BenchSuite/BitPrecise/MultMask.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/MultMask.hs
@@ -1,0 +1,31 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.MultMask
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.MultMask
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.MultMask(benchmarks) where
+
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.runWith conf "MultMask" find
+  ]
+  where find = do mask <- exists "mask"
+                  mult <- exists "mult"
+                  inp  <- forall "inp"
+                  let res = (mask .&. inp) * (mult :: SWord64)
+                  solve [inp `sExtractBits` [7, 15 .. 63] .== res `sExtractBits` [56 .. 63]]
+        conf = z3{printBase=16, satCmd = "(check-sat-using (and-then simplify smtfd))"}

--- a/SBVBenchSuite/BenchSuite/BitPrecise/PrefixSum.hs
+++ b/SBVBenchSuite/BenchSuite/BitPrecise/PrefixSum.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.BitPrecise.PrefixSum
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.BitPrecise.PrefixSum
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.BitPrecise.PrefixSum(benchmarks) where
+
+import Documentation.SBV.Examples.BitPrecise.PrefixSum
+import BenchSuite.Bench.Bench as B
+
+import Data.SBV
+
+-- benchmark suite
+benchmarks :: Runner
+benchmarks = rGroup
+  [ B.run    "Correctness.PrefixSum 8"  (flIsCorrect 8  (0,(+)))  `using` runner proveWith
+  , B.run    "Correctness.PrefixSum 16" (flIsCorrect 16 (0,smax)) `using` runner proveWith
+  ]

--- a/SBVBenchSuite/BenchSuite/Puzzles/Birthday.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Birthday.hs
@@ -16,10 +16,10 @@ module BenchSuite.Puzzles.Birthday(benchmarks) where
 
 import Documentation.SBV.Examples.Puzzles.Birthday
 
+import BenchSuite.Bench.Bench as S
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "Birthday" puzzle `using` setRunner allSatWith
+benchmarks = S.run "Birthday" puzzle `using` runner allSatWith

--- a/SBVBenchSuite/BenchSuite/Puzzles/Coins.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Coins.hs
@@ -17,12 +17,12 @@ module BenchSuite.Puzzles.Coins(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.Coins
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "Coins" coinsPgm
+benchmarks = S.run "Coins" coinsPgm
   where coinsPgm = do cs <- mapM mkCoin [1..6]
                       mapM_ constrain [c s | s <- combinations cs, length s >= 2, c <- [c1, c2, c3, c4, c5, c6]]
                       constrain $ sAnd $ zipWith (.>=) cs (tail cs)

--- a/SBVBenchSuite/BenchSuite/Puzzles/Counts.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Counts.hs
@@ -17,11 +17,11 @@ module BenchSuite.Puzzles.Counts(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.Counts
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "Counts" countPgm `using` setRunner allSatWith
+benchmarks = S.run "Counts" countPgm `using` runner allSatWith
  where countPgm = forAll_ puzzle' >>= return -- avoiding 'output' here again
        puzzle' d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 = puzzle [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9]

--- a/SBVBenchSuite/BenchSuite/Puzzles/DogCatMouse.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/DogCatMouse.hs
@@ -15,12 +15,12 @@
 module BenchSuite.Puzzles.DogCatMouse(benchmarks) where
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "DogCatMouse" p `using` setRunner allSatWith
+benchmarks = S.run "DogCatMouse" p `using` runner allSatWith
   where p = do [dog, cat, mouse] <- sIntegers ["dog", "cat", "mouse"]
                solve [ dog   .>= 1                                   -- at least one dog
                      , cat   .>= 1                                   -- at least one cat

--- a/SBVBenchSuite/BenchSuite/Puzzles/Garden.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Garden.hs
@@ -19,10 +19,10 @@ import Data.List (isSuffixOf)
 import Documentation.SBV.Examples.Puzzles.Garden
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
-benchmarks :: Runner 
-benchmarks = runnerWith s "Garden" puzzle `using` setRunner allSatWith
+benchmarks :: Runner
+benchmarks = S.runWith s "Garden" puzzle `using` runner allSatWith
   where s = z3{satTrackUFs = False, isNonModelVar = ("_modelIgnore" `isSuffixOf`)}

--- a/SBVBenchSuite/BenchSuite/Puzzles/LadyAndTigers.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/LadyAndTigers.hs
@@ -16,12 +16,12 @@ module BenchSuite.Puzzles.LadyAndTigers(benchmarks) where
 
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "Puzzles.LadyAndTigers" p `using` setRunner allSatWith
+benchmarks = S.run "Puzzles.LadyAndTigers" p `using` runner allSatWith
   where p = do
 
           -- One boolean for each of the correctness of the signs

--- a/SBVBenchSuite/BenchSuite/Puzzles/MagicSquare.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/MagicSquare.hs
@@ -17,14 +17,14 @@ module BenchSuite.Puzzles.MagicSquare(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.MagicSquare
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
 benchmarks = rGroup
-  [ runner "MagicSquare.magic 2" (mkMagic 2) `using` setRunner allSatWith
-  , runner "MagicSquare.magic 3" (mkMagic 3) `using` setRunner allSatWith
+  [ S.run "MagicSquare.magic 2" (mkMagic 2) `using` runner allSatWith
+  , S.run "MagicSquare.magic 3" (mkMagic 3) `using` runner allSatWith
   ]
 
 mkMagic :: Int -> Symbolic SBool

--- a/SBVBenchSuite/BenchSuite/Puzzles/NQueens.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/NQueens.hs
@@ -17,20 +17,20 @@ module BenchSuite.Puzzles.NQueens(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.NQueens
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
 benchmarks = rGroup
-  [ runner "NQueens.NQueens 1" (mkQueens 1) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 2" (mkQueens 2) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 3" (mkQueens 3) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 4" (mkQueens 4) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 5" (mkQueens 5) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 6" (mkQueens 6) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 7" (mkQueens 7) `using` setRunner allSatWith
-  , runner "NQueens.NQueens 8" (mkQueens 8) `using` setRunner allSatWith
+  [ S.run "NQueens.NQueens 1" (mkQueens 1) `using` runner allSatWith
+  , S.run "NQueens.NQueens 2" (mkQueens 2) `using` runner allSatWith
+  , S.run "NQueens.NQueens 3" (mkQueens 3) `using` runner allSatWith
+  , S.run "NQueens.NQueens 4" (mkQueens 4) `using` runner allSatWith
+  , S.run "NQueens.NQueens 5" (mkQueens 5) `using` runner allSatWith
+  , S.run "NQueens.NQueens 6" (mkQueens 6) `using` runner allSatWith
+  , S.run "NQueens.NQueens 7" (mkQueens 7) `using` runner allSatWith
+  , S.run "NQueens.NQueens 8" (mkQueens 8) `using` runner allSatWith
   ]
 
 mkQueens :: Int -> Symbolic SBool

--- a/SBVBenchSuite/BenchSuite/Puzzles/SendMoreMoney.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/SendMoreMoney.hs
@@ -16,12 +16,12 @@ module BenchSuite.Puzzles.SendMoreMoney(benchmarks) where
 
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
-benchmarks = runner "Puzzles.SendMoreMoney" p `using` setRunner allSatWith
+benchmarks = S.run "Puzzles.SendMoreMoney" p `using` runner allSatWith
   where p = do
           ds@[s,e,n,d,m,o,r,y] <- mapM sInteger ["s", "e", "n", "d", "m", "o", "r", "y"]
           let isDigit x = x .>= 0 .&& x .<= 9

--- a/SBVBenchSuite/BenchSuite/Puzzles/Sudoku.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/Sudoku.hs
@@ -17,13 +17,13 @@ module BenchSuite.Puzzles.Sudoku(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.Sudoku
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
 benchmarks = rGroup
-    [ runner ("sudoku " ++ show n) (checkPuzzle s) `using` setRunner allSatWith
+    [ S.run ("sudoku " ++ show n) (checkPuzzle s) `using` runner allSatWith
        | (n, s) <-
            zip
              [(0::Int)..]

--- a/SBVBenchSuite/BenchSuite/Puzzles/U2Bridge.hs
+++ b/SBVBenchSuite/BenchSuite/Puzzles/U2Bridge.hs
@@ -17,17 +17,17 @@ module BenchSuite.Puzzles.U2Bridge(benchmarks) where
 import Documentation.SBV.Examples.Puzzles.U2Bridge
 
 import Utils.SBVBenchFramework
-import BenchSuite.Overhead.SBVOverhead
+import BenchSuite.Bench.Bench as S
 
 
 -- benchmark suite
 benchmarks :: Runner
 benchmarks = rGroup
-  [ runner "U2Bridge_cnt1" (count 1) `using` setRunner allSatWith
-  , runner "U2Bridge_cnt2" (count 2) `using` setRunner allSatWith
-  , runner "U2Bridge_cnt3" (count 3) `using` setRunner allSatWith
-  , runner "U2Bridge_cnt4" (count 4) `using` setRunner allSatWith
-  , runner "U2Bridge_cnt6" (count 6) `using` setRunner allSatWith
+  [ S.run "U2Bridge_cnt1" (count 1) `using` runner allSatWith
+  , S.run "U2Bridge_cnt2" (count 2) `using` runner allSatWith
+  , S.run "U2Bridge_cnt3" (count 3) `using` runner allSatWith
+  , S.run "U2Bridge_cnt4" (count 4) `using` runner allSatWith
+  , S.run "U2Bridge_cnt6" (count 6) `using` runner allSatWith
   ]
   where
     act     = do b <- exists_; p1 <- exists_; p2 <- exists_; return (b, p1, p2)

--- a/SBVBenchSuite/BenchSuite/Queries/AllSat.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/AllSat.hs
@@ -1,25 +1,22 @@
 -----------------------------------------------------------------------------
 -- |
--- Module    : BenchSuite.Puzzles.Euler185
+-- Module    : BenchSuite.Queries.AllSat
 -- Copyright : (c) Jeffrey Young
 --                 Levent Erkok
 -- License   : BSD3
 -- Maintainer: erkokl@gmail.com
 -- Stability : experimental
 --
--- Bench suite for Documentation.SBV.Examples.Puzzles.Euler185
+-- Bench suite for Documentation.SBV.Examples.Queries.AllSat
 -----------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -Wall -Werror #-}
 
-module BenchSuite.Puzzles.Euler185(benchmarks) where
+module BenchSuite.Queries.AllSat(benchmarks) where
 
-import Documentation.SBV.Examples.Puzzles.Euler185
+import Documentation.SBV.Examples.Queries.AllSat
 
-import Utils.SBVBenchFramework
-import BenchSuite.Bench.Bench as S
+import BenchSuite.Bench.Bench
 
-
--- benchmark suite
 benchmarks :: Runner
-benchmarks = S.run "Euler185" euler185 `using` runner allSatWith
+benchmarks = runIO "AllSat" demo

--- a/SBVBenchSuite/BenchSuite/Queries/CaseSplit.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/CaseSplit.hs
@@ -1,25 +1,24 @@
 -----------------------------------------------------------------------------
 -- |
--- Module    : BenchSuite.Puzzles.Euler185
+-- Module    : BenchSuite.Queries.CaseSplit
 -- Copyright : (c) Jeffrey Young
 --                 Levent Erkok
 -- License   : BSD3
 -- Maintainer: erkokl@gmail.com
 -- Stability : experimental
 --
--- Bench suite for Documentation.SBV.Examples.Puzzles.Euler185
+-- Bench suite for Documentation.SBV.Examples.Queries.CaseSplit
 -----------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -Wall -Werror #-}
 
-module BenchSuite.Puzzles.Euler185(benchmarks) where
+module BenchSuite.Queries.CaseSplit(benchmarks) where
 
-import Documentation.SBV.Examples.Puzzles.Euler185
+import Documentation.SBV.Examples.Queries.CaseSplit
 
-import Utils.SBVBenchFramework
-import BenchSuite.Bench.Bench as S
+import BenchSuite.Bench.Bench
 
-
--- benchmark suite
 benchmarks :: Runner
-benchmarks = S.run "Euler185" euler185 `using` runner allSatWith
+benchmarks = rGroup [ runIO "CaseSplit.1" csDemo1
+                    , runIO "CaseSplit.2" csDemo2
+                    ]

--- a/SBVBenchSuite/BenchSuite/Queries/Concurrency.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/Concurrency.hs
@@ -1,0 +1,26 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.Concurrency
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.Concurrency
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module BenchSuite.Queries.Concurrency(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.Concurrency
+
+import BenchSuite.Bench.Bench
+
+-- these benchmarks won't run in multithreaded mode. The benchmark target is not
+-- build as -threaded
+benchmarks :: Runner
+benchmarks = rGroup [ runIO "Concurrency.demo"          demo
+                    , runIO "Concurrency.demoDependent" demoDependent
+                    ]

--- a/SBVBenchSuite/BenchSuite/Queries/Enums.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/Enums.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.Enums
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.Enums
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+
+module BenchSuite.Queries.Enums(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.Enums
+
+import Control.DeepSeq
+import BenchSuite.Bench.Bench
+
+-- | orphaned instance for benchmarks
+instance NFData Day where rnf x = seq x ()
+
+benchmarks :: Runner
+benchmarks = rGroup [ runIO "Enums.findDays" findDays
+                    ]

--- a/SBVBenchSuite/BenchSuite/Queries/FourFours.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/FourFours.hs
@@ -1,0 +1,22 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.FourFours
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.FourFours
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+
+module BenchSuite.Queries.FourFours(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.FourFours
+
+import BenchSuite.Bench.Bench
+
+benchmarks :: Runner
+benchmarks =  runIO "FourFours.puzzle" puzzle

--- a/SBVBenchSuite/BenchSuite/Queries/GuessNumber.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/GuessNumber.hs
@@ -1,0 +1,22 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.GuessNumber
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.GuessNumber
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+
+module BenchSuite.Queries.GuessNumber(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.GuessNumber
+
+import BenchSuite.Bench.Bench
+
+benchmarks :: Runner
+benchmarks =  runIO "GuessNumber.play" play

--- a/SBVBenchSuite/BenchSuite/Queries/Interpolants.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/Interpolants.hs
@@ -1,0 +1,24 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.Interpolants
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.Interpolants
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+
+module BenchSuite.Queries.Interpolants(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.Interpolants
+
+import BenchSuite.Bench.Bench
+
+import Data.SBV
+
+benchmarks :: Runner
+benchmarks =  runIO "Interpolants.evenOdd" $ runSMT evenOdd

--- a/SBVBenchSuite/BenchSuite/Queries/UnsatCore.hs
+++ b/SBVBenchSuite/BenchSuite/Queries/UnsatCore.hs
@@ -1,0 +1,22 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module    : BenchSuite.Queries.UnsatCore
+-- Copyright : (c) Jeffrey Young
+--                 Levent Erkok
+-- License   : BSD3
+-- Maintainer: erkokl@gmail.com
+-- Stability : experimental
+--
+-- Bench suite for Documentation.SBV.Examples.Queries.UnsatCore
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+
+module BenchSuite.Queries.UnsatCore(benchmarks) where
+
+import Documentation.SBV.Examples.Queries.UnsatCore
+
+import BenchSuite.Bench.Bench
+
+benchmarks :: Runner
+benchmarks =  runIO "UnsatCore.ucCore" ucCore

--- a/SBVBenchSuite/Utils/SBVBenchFramework.hs
+++ b/SBVBenchSuite/Utils/SBVBenchFramework.hs
@@ -13,7 +13,7 @@
 module Utils.SBVBenchFramework
   ( mkExecString
   , mkFileName
-  , module Criterion.Main
+  , module Gauge.Main
   , module Data.SBV
   ) where
 
@@ -21,7 +21,7 @@ import qualified Data.List      as L
 import           System.Process (showCommandForUser)
 import           System.Random
 
-import           Criterion.Main (Benchmark, bgroup)
+import           Gauge.Main (Benchmark, bgroup)
 
 import           Data.SBV
 

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -168,6 +168,7 @@ Library
                   , Documentation.SBV.Examples.Queries.CaseSplit
                   , Documentation.SBV.Examples.Queries.Enums
                   , Documentation.SBV.Examples.Queries.Interpolants
+                  , Documentation.SBV.Examples.Queries.Concurrency
                   , Documentation.SBV.Examples.Strings.RegexCrossword
                   , Documentation.SBV.Examples.Strings.SQLInjection
                   , Documentation.SBV.Examples.Transformers.SymbolicEval
@@ -411,11 +412,11 @@ Benchmark SBVBench
                     TypeApplications
   Build-depends : base >= 4.11, filepath, syb, crackNum >= 2.3
                 , sbv, directory, random, mtl, containers
-                , criterion, process, deepseq
+                , gauge, process, deepseq, silently
   Hs-Source-Dirs  : SBVBenchSuite
   main-is         : SBVBench.hs
   Other-modules   : Utils.SBVBenchFramework
-                  , BenchSuite.Overhead.SBVOverhead
+                  , BenchSuite.Bench.Bench
                   , BenchSuite.Puzzles.Birthday
                   , BenchSuite.Puzzles.Coins
                   , BenchSuite.Puzzles.Counts
@@ -428,3 +429,17 @@ Benchmark SBVBench
                   , BenchSuite.Puzzles.SendMoreMoney
                   , BenchSuite.Puzzles.Sudoku
                   , BenchSuite.Puzzles.U2Bridge
+                  , BenchSuite.BitPrecise.BitTricks
+                  , BenchSuite.BitPrecise.BrokenSearch
+                  , BenchSuite.BitPrecise.Legato
+                  , BenchSuite.BitPrecise.MergeSort
+                  , BenchSuite.BitPrecise.MultMask
+                  , BenchSuite.BitPrecise.PrefixSum
+                  , BenchSuite.Queries.AllSat
+                  , BenchSuite.Queries.CaseSplit
+                  , BenchSuite.Queries.Concurrency
+                  , BenchSuite.Queries.Enums
+                  , BenchSuite.Queries.FourFours
+                  , BenchSuite.Queries.GuessNumber
+                  , BenchSuite.Queries.Interpolants
+                  , BenchSuite.Queries.UnsatCore


### PR DESCRIPTION
Hey Levent,

Hope you are doing well. I have finally wrapped up a main project and had some time to spend on this. This PR does 3 things for phase 1, discussed in https://github.com/LeventErkok/sbv/issues/484:

1. Replaces criterion with gauge. Gauge has the same functionality but less dependencies
2. reworks the benchmark api to allow bench marking IO computations, while still preserving the flexibility to experiment with bench marking different solver entry points, i.e., `satWith`, `proveWith` etc.
3. Adds `BitPrecise` and `Query` benchmarks. 

If everything looks good to you then over the next week I'd like to add benchmarks for the other examples. My plan is to complete the benchmarks and then write a `tasty` plugin to compare a subset of them across runs. Then finally begin some performance tuning.

Are there any benchmarks which you would consider to be high priority?

- Jeff