### PR TITLE
Cache map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   * Performance updates: Thanks to Jeff Young, SBV now uses better underlying
     data structures, performing better for heavy use-case scenarios.
 
+  * Add unordered-containers dependency
+
 ### Version 8.9, 2020-10-28
 
   * Rename 'sbvAvailableSolvers' to 'getAvailableSolvers'.
@@ -59,11 +61,11 @@
   * Add "extraArgs" parameter to SMTConfig to simplify passing extra command line
     arguments to the solver.
 
-  * Add a method 
+  * Add a method
 
         sListArray :: (HasKind a, SymVal b) => b -> [(SBV a, SBV b)] -> array a b
 
-    to the `SymArray` class, which allows for creation of arrays from lists of constant or 
+    to the `SymArray` class, which allows for creation of arrays from lists of constant or
     symbolic lists of pairs. The first argument is the value to use for uninitialized entries.
     Note that the initializer must be a known constant, i.e., it cannot be symbolic. Latter
     elements of the list will overwrite the earlier ones, if there are repeated keys.
@@ -108,7 +110,7 @@
     need its functionality back.
 
   * Reworked SBVBenchSuite api, Phase 1 of BenchSuite completed.
-  
+
   * Add support for addAxiom command to work in the interactive mode.
     Thanks to Martin Lundfall for the feedback.
 

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -91,7 +91,7 @@ import qualified Control.Monad.Writer.Lazy   as LW
 import qualified Control.Monad.Writer.Strict as SW
 import qualified Data.IORef                  as R    (modifyIORef')
 import qualified Data.Generics               as G    (Data(..))
-import qualified Data.IntMap.Strict          as IMap (IntMap, empty, toAscList, lookup, insertWith)
+import qualified Data.IntMap.Strict          as IMap (IntMap, empty, toAscList)
 import qualified Data.Map.Strict             as Map  (Map, empty, toList, lookup, insert, size)
 import qualified Data.HashMap.Strict         as HMap (HashMap, lookup,insert,empty)
 import qualified Data.Set                    as Set  (Set, empty, toList, insert, member)
@@ -1651,9 +1651,9 @@ runSymbolic currentRunMode (SymbolicT c) = do
      uis       <- newIORef Map.empty
      cgs       <- newIORef Map.empty
      axioms    <- newIORef []
-     swCache   <- newIORef IMap.empty
-     aiCache   <- newIORef IMap.empty
-     faiCache  <- newIORef IMap.empty
+     swCache   <- newIORef HMap.empty
+     aiCache   <- newIORef HMap.empty
+     faiCache  <- newIORef HMap.empty
      usedKinds <- newIORef Set.empty
      usedLbls  <- newIORef Set.empty
      cstrs     <- newIORef S.empty

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -1856,7 +1856,7 @@ uncacheGen :: (State -> IORef (Cache a)) -> Cached a -> State -> IO a
 uncacheGen getCache (Cached f) st = do
         let rCache = getCache st
         stored <- readIORef rCache
-        sn <- f `seq` makeStableName f
+        sn <- makeStableName f
         case (sn `HMap.lookup` stored) of
           Just r  -> return r
           Nothing -> do r <- f st

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -84,6 +84,7 @@ Library
                   , QuickCheck, template-haskell
                   , array, async, containers, deepseq, directory, filepath, time
                   , pretty, process, mtl, random, syb, text, transformers, uniplate
+                  , unordered-containers
   Exposed-modules : Data.SBV
                   , Data.SBV.Control
                   , Data.SBV.Dynamic


### PR DESCRIPTION
Hey Levent,

**This PR adds a `unordered-containers` dependency, which IMHO is very low risk as its a fairly standard library to use.**

I was doing some profiling and believe I rediscovered the bug from #460 although this time I actually fixed it. Essentially there was a space leak in `Cache` from too much laziness. The space leak centers around this type:

```
-- | Cached values, implementing sharing
type Cache a   = IMap.IntMap [(StableName (State -> IO a), a)]
```

there are two problems with this type. First `IntMap.Strict` evaluates its values to weak-head normal form, but for a list that is just a `Cons` cell, thus using `IntMap.Strict` won't make the list value strict, only spine strict. Secondly, the tuple type is also overly lazy and will behave similarly to the list, i.e., it will also evaluate to weak-head normal form and not the internal values, thus the values can easily build up thunks.

All profiles were built from re-using code we had in #460:
```
Import Control.Monad
import qualified Data.SBV as S

main = do
  let go x acc = let s = x S..&& acc
                     in do S.constrain s
                           return s
      bad = S.sat $ do bs <- mapM (const S.free_) [1..10000]
                       foldM go S.sTrue bs

  print =<< show <$> bad
```

Here is the initial profile, you can see that `sbv` is building up thunks of lists of tuples and `IntMap` is exploding so bad that nothing else even shows up, check out the y-axis scale:

[auto_problem.pdf](https://github.com/LeventErkok/sbv/files/5744129/auto_problem.pdf)

So I tried several strategies. The best strategy by far is the just use an `IntMap a` and call `hashStableName` for the key. Which results in this profile:

[auto_imap.pdf](https://github.com/LeventErkok/sbv/files/5744118/auto_imap.pdf)

unfortunately only using an `IntMap` produces incorrect results. Next I tried to replace the list with a `HashMap (StableName (State -> IO a)) a` which will has the stable name and use it as a key value. This measurably improved the leak, notice the memory load is around 1/2, I killed this early hence the emptiness in the plot:
```
type Cache a   = IMap.IntMap (HashMap (StableName (State -> IO a))  a)
```
[auto_imap_hmap.pdf](https://github.com/LeventErkok/sbv/files/5744122/auto_imap_hmap.pdf)

but this implementation is redundant because the `Hashable` instance of `StableName` calls `hashStableName` so next I just used a `HashMap` rather than an `IntMap`. This results in the best performance and fixes the leak:

[auto_list_leak.pdf](https://github.com/LeventErkok/sbv/files/5744127/auto_list_leak.pdf)

This implementation also passed the test suite and I spot checked the `Euler185` and `U2` doctests, both were correct. You'll notice that there is a space leak in the last profile with a list type (you can tell by the pyramid shape profile, a bunch of thunks being built up (this is the rise) then being called and evaluated (this is the fall)). I'm not too sure what this is yet but I suspect it is a `String` of some kind.

One last note. You'll notice I increased the laziness of the `StableName` by removing `f `seq``, this likely reduces sharing in the cache but I received better performance by keeping this lazy. This may just be reflective of my testing being overly specific. I'll leave it up to you whether you want to add the `seq` back in or not. The docs for `StableName` suggest strictness to increase sharing if you need more caching or leaving it lazy if the application requires laziness. 

