### PR TITLE
UncacheGen implemented with IntMap

### DIFF
--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -91,9 +91,8 @@ import qualified Control.Monad.Writer.Lazy   as LW
 import qualified Control.Monad.Writer.Strict as SW
 import qualified Data.IORef                  as R    (modifyIORef')
 import qualified Data.Generics               as G    (Data(..))
-import qualified Data.IntMap.Strict          as IMap (IntMap, empty, toAscList)
+import qualified Data.IntMap.Strict          as IMap (IntMap, empty, toAscList, lookup, empty, insertWith)
 import qualified Data.Map.Strict             as Map  (Map, empty, toList, lookup, insert, size)
-import qualified Data.HashMap.Strict         as HMap (HashMap, lookup,empty,insertWith)
 import qualified Data.Set                    as Set  (Set, empty, toList, insert, member)
 import qualified Data.Foldable               as F    (toList)
 import qualified Data.Sequence               as S    (Seq, empty, (|>), (<|), filter, takeWhileL, fromList, lookup, elemIndexL, findIndexL, (><))
@@ -881,7 +880,7 @@ type UIMap     = Map.Map String SBVType
 type CgMap     = Map.Map String [String]
 
 -- | Cached values, implementing sharing
-type Cache a   = HMap.HashMap (StableName (State -> IO a)) (S.Seq (SPair (StableName (State -> IO a)) a))
+type Cache a   = IMap.IntMap (S.Seq (SPair (StableName (State -> IO a)) a))
 
 -- | A strict pair
 data SPair a b = SPair !a !b
@@ -1660,9 +1659,9 @@ runSymbolic currentRunMode (SymbolicT c) = do
      uis       <- newIORef Map.empty
      cgs       <- newIORef Map.empty
      axioms    <- newIORef []
-     swCache   <- newIORef HMap.empty
-     aiCache   <- newIORef HMap.empty
-     faiCache  <- newIORef HMap.empty
+     swCache   <- newIORef IMap.empty
+     aiCache   <- newIORef IMap.empty
+     faiCache  <- newIORef IMap.empty
      usedKinds <- newIORef Set.empty
      usedLbls  <- newIORef Set.empty
      cstrs     <- newIORef S.empty
@@ -1868,10 +1867,11 @@ uncacheGen getCache (Cached f) st = do
         sn <- makeStableName f
         let find ss = do i <- S.findIndexL (eqStableName sn . fstStrict) ss
                          sndStrict <$> S.lookup i ss
-        case (sn `HMap.lookup` stored) >>= find of
+            h = hashStableName sn
+        case (h `IMap.lookup` stored) >>= find of
           Just r  -> return r
           Nothing -> do r <- f st
-                        r `seq` R.modifyIORef' rCache (HMap.insertWith (S.><) sn . pure $ SPair sn r)
+                        r `seq` R.modifyIORef' rCache (IMap.insertWith (S.><) h . pure $ SPair sn r)
                         return r
 
 -- | Representation of SMTLib Program versions. As of June 2015, we're dropping support

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -84,7 +84,6 @@ Library
                   , QuickCheck, template-haskell
                   , array, async, containers, deepseq, directory, filepath, time
                   , pretty, process, mtl, random, syb, text, transformers, uniplate
-                  , unordered-containers
   Exposed-modules : Data.SBV
                   , Data.SBV.Control
                   , Data.SBV.Dynamic


### PR DESCRIPTION
PR to remove `HashMap` implementation of uncacheGen after identifying `f `seq` makeStableName` as source of space leak. See #572 and #571 