### PR TITLE
Allow building with GHC 9.0

### DIFF
--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -57,6 +57,7 @@ import Data.Array  (Array, Ix, listArray, elems, bounds, rangeSize)
 import Data.Bits   (Bits(..))
 import Data.Char   (toLower, isDigit)
 import Data.Int    (Int8, Int16, Int32, Int64)
+import Data.Kind   (Type)
 import Data.List   (genericLength, genericIndex, genericTake, unzip4, unzip5, unzip6, unzip7, intercalate, isPrefixOf)
 import Data.Maybe  (fromMaybe, mapMaybe)
 import Data.String (IsString(..))
@@ -2400,7 +2401,7 @@ class Metric a where
   -- | The metric space we optimize the goal over. Usually the same as the type itself, but not always!
   -- For instance, signed bit-vectors are optimized over their unsigned counterparts, floats are
   -- optimized over their 'Word32' comparable counterparts, etc.
-  type MetricSpace a :: *
+  type MetricSpace a :: Type
   type MetricSpace a = a
 
   -- | Compute the metric value to optimize.

--- a/Data/SBV/Utils/PrettyNum.hs
+++ b/Data/SBV/Utils/PrettyNum.hs
@@ -471,7 +471,7 @@ cvToSMTLib rm x
         dtConstructor fld args res = "((as " ++ fld ++ " " ++ smtType res ++ ") " ++ unwords args ++ ")"
 
         smtLibMaybe :: Kind -> Maybe CVal -> String
-        smtLibMaybe km@ KMaybe{}  Nothing   = dtConstructor "nothing_SBVMaybe" []                       km
+        smtLibMaybe km@KMaybe{}   Nothing   = dtConstructor "nothing_SBVMaybe" []                       km
         smtLibMaybe km@(KMaybe k) (Just  c) = dtConstructor "just_SBVMaybe"    [cvToSMTLib rm (CV k c)] km
         smtLibMaybe k             _         = error $ "SBV.cvToSMTLib: Impossible case (smtLibMaybe), received kind: " ++ show k
 

--- a/Documentation/SBV/Examples/Transformers/SymbolicEval.hs
+++ b/Documentation/SBV/Examples/Transformers/SymbolicEval.hs
@@ -34,6 +34,7 @@ import Control.Monad.Identity (Identity(runIdentity))
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader   (MonadReader(reader), asks, ReaderT, runReaderT)
 import Control.Monad.Trans    (lift)
+import Data.Kind              (Type)
 
 import Data.SBV.Dynamic   (SVal)
 import Data.SBV.Internals (SBV(SBV), unSBV)
@@ -72,7 +73,7 @@ allocEnv = do
 -- * Symbolic term evaluation
 
 -- | The term language we use to express programs and properties.
-data Term :: * -> * where
+data Term :: Type -> Type where
     Var         :: String                       -> Term r
     Lit         :: Integer                      -> Term Integer
     Plus        :: Term Integer -> Term Integer -> Term Integer

--- a/SBVBenchSuite/BenchSuite/Bench/Bench.hs
+++ b/SBVBenchSuite/BenchSuite/Bench/Bench.hs
@@ -91,9 +91,9 @@ using = flip ($)
 -- | Set the runner function
 runner :: (Show c, NFData c) =>
   (forall a. U.Provable a => U.SMTConfig -> a -> IO c) -> Runner -> Runner
-runner r' (Runner r@RunnerI{..}) = Runner $ r{runI = toRun r'}
-runner r' (RunnerGroup rs)       = RunnerGroup $ runner r' <$> rs
-runner _  x                      = x
+runner r' (Runner r@RunnerI{}) = Runner $ r{runI = toRun r'}
+runner r' (RunnerGroup rs)     = RunnerGroup $ runner r' <$> rs
+runner _  x                    = x
 {-# INLINE runner #-}
 
 toRun :: (Show c, NFData c) =>
@@ -189,10 +189,10 @@ mkOverheadBenchMark' r@RunnerI{..} =
 {-# INLINE mkOverheadBenchMark' #-}
 
 runOverheadBenchmark :: Runner -> G.Benchmark
-runOverheadBenchmark (Runner r@RunnerI{..}) = mkOverheadBenchMark' r
-runOverheadBenchmark (RunnerGroup rs)       = G.bgroup "" $ -- leave the description close to the benchmark/problem definition
-                                             runOverheadBenchmark <$> rs
-runOverheadBenchmark (RBenchmark b)         = b
+runOverheadBenchmark (Runner r@RunnerI{}) = mkOverheadBenchMark' r
+runOverheadBenchmark (RunnerGroup rs)     = G.bgroup "" $ -- leave the description close to the benchmark/problem definition
+                                            runOverheadBenchmark <$> rs
+runOverheadBenchmark (RBenchmark b)       = b
 {-# INLINE runOverheadBenchmark #-}
 
 -- | make a normal benchmark without the overhead comparison. Notice this is
@@ -205,9 +205,9 @@ mkBenchmark RunnerI{..} = G.bench description . G.nfIO $! runI config problem
 -- function to convert the runners defined in each file to benchmarks which can
 -- be run by gauge
 runBenchmark :: Runner -> G.Benchmark
-runBenchmark (Runner r@RunnerI{..}) = mkBenchmark r
-runBenchmark (RunnerGroup rs)       = G.bgroup "" $ runBenchmark <$> rs
-runBenchmark (RBenchmark b)         = b
+runBenchmark (Runner r@RunnerI{}) = mkBenchmark r
+runBenchmark (RunnerGroup rs)     = G.bgroup "" $ runBenchmark <$> rs
+runBenchmark (RBenchmark b)       = b
 {-# INLINE runBenchmark #-}
 
 -- | This is just a wrapper around the RunnerI constructor and serves as the main

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -537,7 +537,7 @@ Benchmark SBVBench
                     TemplateHaskell
                     TupleSections
                     TypeApplications
-  build-depends   : filepath, syb, crackNum
+  build-depends   : filepath, syb, crackNum, text
                   , sbv, directory, random, mtl, containers, time
                   , gauge, process, deepseq, silently, bench-show
   hs-source-dirs  : SBVBenchSuite


### PR DESCRIPTION
This patch contains a collection of minor fixes needed to make `sbv` compile with GHC 9.0:

* A space character in the middle of an `@`-pattern was removed in order to conform with GHC proposal 229, which is implemented in 9.0. (See https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst)
* GHC 9.0 features some new warnings in `-Wall`:

  * `-Wstar-is-type`, which warns about using `*` instead of `Type`.
  * `-Wunused-record-wildcards`, which warns about record wildcard matches where none of the bound variables are used.

  Both of these are straightforward to fix.