### PR TITLE
make extractModel work on strings

### DIFF
--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE FlexibleInstances		#-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}
 
@@ -323,10 +324,20 @@ instance SatModel CV where
 -- | A rounding mode, extracted from a model. (Default definition suffices)
 instance SatModel RoundingMode
 
+-- | 'String' as extracted from a model
+instance {-# OVERLAPS #-} SatModel [Char] where
+  parseCVs (CV _ (CString c):r) = Just (c, r)
+  parseCVs _ = Nothing
+
+-- | 'Char' as extracted from a model
+instance SatModel Char where
+  parseCVs (CV _ (CChar c):r) = Just (c, r)
+  parseCVs _ = Nothing
+
 -- | A list of values as extracted from a model. When reading a list, we
 -- go as long as we can (maximal-munch). Note that this never fails, as
 -- we can always return the empty list!
-instance SatModel a => SatModel [a] where
+instance {-# OVERLAPPABLE #-} SatModel a => SatModel [a] where
   parseCVs [] = Just ([], [])
   parseCVs xs = case parseCVs xs of
                   Just (a, ys) -> case parseCVs ys of

--- a/Data/SBV/Utils/Lib.hs
+++ b/Data/SBV/Utils/Lib.hs
@@ -118,7 +118,6 @@ qfsToString = go
         go ('\\':'u':'{':      d2:d1:d0:'}' : rest) | [(v, "")] <- readHex [        d2, d1, d0] = chr v : go rest
         go ('\\':'u':'{':         d1:d0:'}' : rest) | [(v, "")] <- readHex [            d1, d0] = chr v : go rest
         go ('\\':'u':'{':            d0:'}' : rest) | [(v, "")] <- readHex [                d0] = chr v : go rest
-        go ('\\':'x':             d1:d0     : rest) | [(v, "")] <- readHex [            d1, d0] = chr v : go rest
 
         -- Otherwise, just proceed; hopefully we covered everything above
         go (c : rest) = c : go rest

--- a/Data/SBV/Utils/Lib.hs
+++ b/Data/SBV/Utils/Lib.hs
@@ -118,7 +118,7 @@ qfsToString = go
         go ('\\':'u':'{':      d2:d1:d0:'}' : rest) | [(v, "")] <- readHex [        d2, d1, d0] = chr v : go rest
         go ('\\':'u':'{':         d1:d0:'}' : rest) | [(v, "")] <- readHex [            d1, d0] = chr v : go rest
         go ('\\':'u':'{':            d0:'}' : rest) | [(v, "")] <- readHex [                d0] = chr v : go rest
-        go ('\\':'x':             d1:d0     : rest) | [(v, "")] <- readHex [               d1, d0] = chr v : go rest
+        go ('\\':'x':             d1:d0     : rest) | [(v, "")] <- readHex [            d1, d0] = chr v : go rest
 
         -- Otherwise, just proceed; hopefully we covered everything above
         go (c : rest) = c : go rest

--- a/Data/SBV/Utils/Lib.hs
+++ b/Data/SBV/Utils/Lib.hs
@@ -118,6 +118,7 @@ qfsToString = go
         go ('\\':'u':'{':      d2:d1:d0:'}' : rest) | [(v, "")] <- readHex [        d2, d1, d0] = chr v : go rest
         go ('\\':'u':'{':         d1:d0:'}' : rest) | [(v, "")] <- readHex [            d1, d0] = chr v : go rest
         go ('\\':'u':'{':            d0:'}' : rest) | [(v, "")] <- readHex [                d0] = chr v : go rest
+        go ('\\':'x':             d1:d0     : rest) | [(v, "")] <- readHex [               d1, d0] = chr v : go rest
 
         -- Otherwise, just proceed; hopefully we covered everything above
         go (c : rest) = c : go rest


### PR DESCRIPTION
Currently there seem to be no way to extract models if they contain strings or characters (e.g. `extractModel <$> prove ( \x -> x .== (literal "")  ) :: IO (Maybe String)` fails) because SatModel has no appropriate instances defined.
This PR is to create these instances. Tested with the latest z3 (4.8.12).