### PR TITLE
Consistently export solvers `from Data.SBV.{Dynamic,Trans}`

### DIFF
--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -92,7 +92,7 @@ module Data.SBV.Dynamic
   -- ** Programmable model extraction
   , genParse, getModelAssignment, getModelDictionary
   -- * SMT Interface: Configurations and solvers
-  , SMTConfig(..), SMTLibVersion(..), Solver(..), SMTSolver(..), boolector, cvc4, yices, z3, mathSAT, abc, defaultSolverConfig, defaultSMTCfg, sbvCheckSolverInstallation, getAvailableSolvers
+  , SMTConfig(..), SMTLibVersion(..), Solver(..), SMTSolver(..), boolector, bitwuzla, cvc4, cvc5, dReal, yices, z3, mathSAT, abc, defaultSolverConfig, defaultSMTCfg, sbvCheckSolverInstallation, getAvailableSolvers
 
   -- * Symbolic computations
   , outputSVal
@@ -144,7 +144,7 @@ import Data.SBV.Compilers.CodeGen ( SBVCodeGen
                                   )
 import Data.SBV.Compilers.C       (compileToC, compileToCLib)
 
-import Data.SBV.Provers.Prover (boolector, cvc4, yices, z3, mathSAT, abc, defaultSMTCfg)
+import Data.SBV.Provers.Prover (boolector, bitwuzla, cvc4, cvc5, dReal, yices, z3, mathSAT, abc, defaultSMTCfg)
 import Data.SBV.SMT.SMT        (ThmResult(..), SatResult(..), SafeResult(..), OptimizeResult(..), AllSatResult(..), genParse)
 import Data.SBV                (sbvCheckSolverInstallation, defaultSolverConfig, getAvailableSolvers)
 

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -145,7 +145,7 @@ module Data.SBV.Trans (
   -- ** Controlling verbosity
 
   -- ** Solvers
-  , boolector, cvc4, yices, z3, mathSAT, abc
+  , boolector, bitwuzla, cvc4, cvc5, dReal, yices, z3, mathSAT, abc
   -- ** Configurations
   , defaultSolverConfig, defaultSMTCfg, sbvCheckSolverInstallation, getAvailableSolvers
   , setLogic, Logic(..), setOption, setInfo, setTimeOut


### PR DESCRIPTION
Data.SBV exports the `bitwuzla`, `cvc5`, and `dReal` solvers, but none of them are exported from `Data.SBV.Dynamic` or `Data.SBV.Trans`. This patch re-exports them from the latter to keep things consistent across all modules.