### PR TITLE
support building with ghc-9.6 / base >=4.18.0.0

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -464,7 +464,7 @@ import Data.SBV.Control.Types (SMTReasonUnknown(..), Logic(..))
 import qualified Data.SBV.Utils.CrackNum as CN
 
 import Data.Proxy (Proxy(..))
-import GHC.TypeLits
+import GHC.TypeLits (KnownNat, type (<=), type (+), type (-))
 
 import Prelude hiding((+), (-), (*)) -- to avoid the haddock ambiguity
 

--- a/Data/SBV/Client/BaseIO.hs
+++ b/Data/SBV/Client/BaseIO.hs
@@ -39,7 +39,7 @@ import Data.SBV.Provers.Prover (Provable, SExecutable, ThmResult)
 import Data.SBV.SMT.SMT        (AllSatResult, SafeResult, SatResult,
                                 OptimizeResult)
 
-import GHC.TypeLits
+import GHC.TypeLits (KnownNat, TypeError, ErrorMessage(..))
 import Data.Kind
 
 import Data.Int

--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -63,7 +63,7 @@ module Data.SBV.Core.Data
  , QuantifiedBool(..)
  ) where
 
-import GHC.TypeLits
+import GHC.TypeLits (Nat)
 
 import GHC.Generics (Generic)
 import GHC.Exts     (IsList(..))

--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -63,7 +63,7 @@ module Data.SBV.Core.Data
  , QuantifiedBool(..)
  ) where
 
-import GHC.TypeLits (Nat)
+import GHC.TypeLits (KnownNat, Nat)
 
 import GHC.Generics (Generic)
 import GHC.Exts     (IsList(..))


### PR DESCRIPTION
In `base >=4.18.0.0` `SChar` is exported from `GHC.TypeLits` which causes a conflict with the symbol of the same name in `sbv`. Using `GHC.TypeLits` with an explicit imports list avoids that disambiguates the use of `SChar`.