### PR TITLE
benchsuite: compile with MProvable and MSatisfiable

### DIFF
--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -35,6 +35,7 @@ module Data.SBV.Internals (
 
   -- * Operations useful for instantiating SBV type classes
   , genLiteral, genFromCV, CV(..), genMkSymVar, genParse, showModel, SMTModel(..), liftQRem, liftDMod, registerKind, svToSV
+  , MProvable()
 
   -- * Compilation to C, extras
   , compileToC', compileToCLib'
@@ -80,6 +81,8 @@ import Data.SBV.Compilers.C       (compileToC', compileToCLib')
 import Data.SBV.Compilers.CodeGen
 
 import Data.SBV.SMT.SMT (genParse, showModel)
+
+import Data.SBV.Provers.Prover (MProvable)
 
 import Data.SBV.Utils.Numeric
 

--- a/SBVBenchSuite/Utils/SBVBenchFramework.hs
+++ b/SBVBenchSuite/Utils/SBVBenchFramework.hs
@@ -11,6 +11,10 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-missing-methods #-} -- for MProvable orphan
 
 module Utils.SBVBenchFramework
   ( mkExecString
@@ -34,6 +38,7 @@ import           Data.Time.Clock
 import           Data.Time.Calendar
 
 import           Data.SBV
+import           Data.SBV.Internals
 
 -- | make the string to call executable from the command line. All the heavy
 -- lifting is done by 'System.Process.showCommandForUser', the rest is just
@@ -112,3 +117,10 @@ filterOverhead e fp = do (header:file) <- L.lines <$> readFile fp
                              filteredFilePath  = fp ++ "_filtered"
                          writeFile  filteredFilePath (concat $ header:filteredContent)
                          return filteredFilePath
+
+-- NO INSTANCE ON PURPOSE; don't want to prove goals. We provide this instance
+-- just to allow the testsuite to run tests with try to Prove Goals. In general,
+-- this violates the invariants promised by the @MProvable@ and @MSatisfiable@
+-- type classes. Thus, this should not be publicly exposed under any
+-- circumstances.
+instance MProvable IO (SymbolicT IO ())


### PR DESCRIPTION
Hey Levent,

I think I have #649 sorted out. My hunch was right about the Existential:

```
data Problem = forall a . (U.Provable a, U.Satisfiable a) => Problem a
```

That existential basically allows the benchsuite to abstract over _how_ the code is run. Without it, I'm not sure how we would be able to right benchmarks that are run in different ways like in `BenchSuite.Uninterpreted.Multiply`:
```
benchmarks :: Runner
benchmarks = rGroup
  [ run "synthMul22" synthMul22 `using` runner satWith
  , run "Correctness" correct `using` runner proveWith
  ]
```

But now we have a different problem. Because I changed the constraints on `Problem` we have a lot of Benchmarks that now require a `Provable` instance over `Goal`. So I get a handful of these kinds of errors now:

```
SBVBenchSuite/BenchSuite/Uninterpreted/Multiply.hs:25:5: error:
    • No instance for (sbv-10.0:Data.SBV.Provers.Prover.MProvable
                         IO Goal)
        arising from a use of ‘run’
    • In the first argument of ‘using’, namely
        ‘run "synthMul22" synthMul22’
      In the expression:
        run "synthMul22" synthMul22 `using` runner satWith
      In the first argument of ‘rGroup’, namely
        ‘[run "synthMul22" synthMul22 `using` runner satWith,
          run "Correctness" correct `using` runner proveWith]’
   |
25 |   [ run "synthMul22" synthMul22 `using` runner satWith
```

This instance is required because `run` does not know if we'll be proving or checking sat. That is determined with the `using` combinator and the `fooWith` functions exported from SBV, so we have to require both constraints on `run` unless we want to re-architect the benchmark suite (which I don't really have time to do, but could be a good first contributor ticket).

So I think we have two paths forward:

1) bite the bullet and just disable the benchmarks that require the `Provable Goal` instance. We're looking at around 8-10 benchmarks here. The larger problem is that then the benchmark suite would not be testing these code paths!
2) We could move the `Provable Goal` instance into the benchmark suite just as a hack. This way it wouldn't need to be a part of the public API. The only catch is that this would mean exporting the `ExtractIO` module so that I can import it in the benchmark suite and write the bad instance.

I'm somewhat partial to (2), what do you think?