### PR TITLE
Support building with mtl-2.3 (GHC 9.6)

### DIFF
--- a/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
+++ b/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
@@ -29,6 +29,7 @@ module Documentation.SBV.Examples.Puzzles.AOC_2021_24 where
 
 import Prelude hiding (read, mod, div)
 
+import Control.Monad (forM_)
 import Data.Maybe
 
 import qualified Data.Map.Strict          as M
@@ -169,7 +170,7 @@ puzzle shouldMaximize = print =<< optimizeWith z3{isNonModelVar = (/= finalVar)}
                      let digits = reverse inputs
 
                      -- Each digit is between 1-9
-                     ST.forM_ digits $ \d -> constrain $ d `inRange` (1, 9)
+                     forM_ digits $ \d -> constrain $ d `inRange` (1, 9)
 
                      -- Digits spell out the model number. We minimize/maximize this value as requested:
                      let modelNum = foldl (\sofar d -> 10 * sofar + d) 0 digits

--- a/SBVTestSuite/TestSuite/Basics/BoundedList.hs
+++ b/SBVTestSuite/TestSuite/Basics/BoundedList.hs
@@ -25,7 +25,8 @@ import Data.SBV.List ((.:), (!!))
 import qualified Data.SBV.List as L
 import qualified Data.SBV.Tools.BoundedList as BL
 
-import Control.Monad.State
+import Control.Monad (unless)
+import Control.Monad.State (MonadState(..), State, modify, runState)
 
 -- | Flag to mark a failed computation
 newtype Failure = Failure SBool

--- a/SBVTestSuite/Utils/SBVTestFramework.hs
+++ b/SBVTestSuite/Utils/SBVTestFramework.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies    #-}
 {-# LANGUAGE TypeOperators   #-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}


### PR DESCRIPTION
`mtl-2.3` no longer re-exports `Control.Monad` from `Control.Monad.State`, so we must address this by explicitly importing some things from `Control.Monad`.

I also noticed that the test suite does not currently build with GHC 9.2.7, so I added a fix for that in a separate commit.