### PR TITLE
Update minimum base dependency to 4.16

### DIFF
--- a/Data/SBV/Tools/BMC.hs
+++ b/Data/SBV/Tools/BMC.hs
@@ -11,6 +11,7 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE TypeOperators    #-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}

--- a/Data/SBV/Tools/Induction.hs
+++ b/Data/SBV/Tools/Induction.hs
@@ -20,6 +20,7 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE TypeOperators    #-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}

--- a/Data/SBV/Tools/WeakestPreconditions.hs
+++ b/Data/SBV/Tools/WeakestPreconditions.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE NamedFieldPuns         #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -30,7 +30,7 @@ source-repository head
 common common-settings
    default-language: Haskell2010
    ghc-options     : -Wall -O2
-   build-depends   : base >= 4.11 && < 5
+   build-depends   : base >= 4.17 && < 5
 
    if impl(ghc >= 8.10.1)
       ghc-options  : -Wunused-packages

--- a/sbv.cabal
+++ b/sbv.cabal
@@ -30,7 +30,7 @@ source-repository head
 common common-settings
    default-language: Haskell2010
    ghc-options     : -Wall -O2
-   build-depends   : base >= 4.17 && < 5
+   build-depends   : base >= 4.16 && < 5
 
    if impl(ghc >= 8.10.1)
       ghc-options  : -Wunused-packages


### PR DESCRIPTION
This pull request updates the minimum base dependency to 4.17 (GHC 9.4), which resolves issue #655. I have confirmed that the current version of the code builds successfully with GHC 9.4, but not with earlier versions such as GHC 9.2.

The reason for this is that the commit d09d300 introduced equality constraints, which require either the GADTs or TypeFamilies extension in earlier GHC versions. If you prefer, I can also fix the code by adding the extensions to use base version 4.16 instead, and ensure compatibility with GHC 9.2. Let me know your thoughts on this.