### PR TITLE
Use new-style HLint comments

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -1613,4 +1613,4 @@ checkSpecialRelation op rel = SBV $ SVal KBool $ Right $ cache result
 
                        newExpr st KBool $ SBVApp (SpecialRelOp ka iop) []
 
-{-# ANN module ("HLint: ignore Use import/export shortcut" :: String) #-}
+{- HLint ignore module "Use import/export shortcut" -}

--- a/Data/SBV/Compilers/C.hs
+++ b/Data/SBV/Compilers/C.hs
@@ -1069,4 +1069,4 @@ getLDFlag (o, k) = flag o
                        , FP_IsZero
                        ]
 
-{-# ANN module ("HLint: ignore Redundant lambda" :: String) #-}
+{- HLint ignore module "Redundant lambda" -}

--- a/Data/SBV/Control/Query.hs
+++ b/Data/SBV/Control/Query.hs
@@ -838,4 +838,4 @@ mkSMTResult asgns = do
 
              return $ Satisfiable queryConfig m
 
-{-# ANN getModelAtIndex ("HLint: ignore Use forM_" :: String) #-}
+{- HLint ignore getModelAtIndex "Use forM_" -}

--- a/Data/SBV/Control/Types.hs
+++ b/Data/SBV/Control/Types.hs
@@ -251,5 +251,5 @@ instance Show Logic where
   show Logic_NONE      = "Logic_NONE"
   show (CustomLogic l) = l
 
-{-# ANN type SMTInfoResponse ("HLint: ignore Use camelCase" :: String) #-}
-{-# ANN type Logic           ("HLint: ignore Use camelCase" :: String) #-}
+{- HLint ignore type SMTInfoResponse "Use camelCase" -}
+{- HLint ignore type Logic           "Use camelCase" -}

--- a/Data/SBV/Control/Utils.hs
+++ b/Data/SBV/Control/Utils.hs
@@ -1768,5 +1768,5 @@ executeQuery queryContext (QueryT userQuery) = do
                                           , "*** and each call to runSMT should have only one query call inside."
                                           ]
 
-{-# ANN module          ("HLint: ignore Reduce duplication" :: String) #-}
-{-# ANN getAllSatResult ("HLint: ignore Use forM_"          :: String) #-}
+{- HLint ignore module          "Reduce duplication" -}
+{- HLint ignore getAllSatResult "Use forM_"          -}

--- a/Data/SBV/Core/Concrete.hs
+++ b/Data/SBV/Core/Concrete.hs
@@ -523,4 +523,4 @@ randomCVal k =
 randomCV :: Kind -> IO CV
 randomCV k = CV k <$> randomCVal k
 
-{-# ANN module ("HLint: ignore Redundant if" :: String) #-}
+{- HLint ignore module "Redundant if" -}

--- a/Data/SBV/Core/Floating.hs
+++ b/Data/SBV/Core/Floating.hs
@@ -763,4 +763,4 @@ instance ValidFloat eb sb => IEEEFloating (FloatingPoint eb sb) where
   --       fpIsPositiveZero :: SBV a -> SBool
   --       fpIsPoint        :: SBV a -> SBool
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -2781,5 +2781,5 @@ lambdaAsArray f = SArray $ SArr (kindOf (Proxy @a), kindOf (Proxy @b)) $ cache g
 
                   extract =<< newArrayInState Nothing (Right def) st
 
-{-# ANN module   ("HLint: ignore Reduce duplication" :: String) #-}
-{-# ANN module   ("HLint: ignore Eta reduce" :: String)         #-}
+{- HLint ignore module   "Reduce duplication" -}
+{- HLint ignore module   "Eta reduce"         -}

--- a/Data/SBV/Core/Operations.hs
+++ b/Data/SBV/Core/Operations.hs
@@ -41,7 +41,7 @@ module Data.SBV.Core.Operations
   , svBarrelRotateLeft, svBarrelRotateRight
   , svBlastLE, svBlastBE
   , svAddConstant, svIncrement, svDecrement
-  , svFloatAsSWord32, svDoubleAsSWord64, svFloatingPointAsSWord 
+  , svFloatAsSWord32, svDoubleAsSWord64, svFloatingPointAsSWord
   -- ** Basic array operations
   , SArr(..), readSArr, writeSArr, mergeSArr, newSArr, eqSArr
   -- Utils
@@ -1452,6 +1452,6 @@ svFloatingPointAsSWord fVal@(SVal kFrom@(KFP eb sb) _)
                              return n
 svFloatingPointAsSWord (SVal k _) = error $ "svFloatingPointAsSWord: non-float type: " ++ show k
 
-{-# ANN svIte     ("HLint: ignore Eta reduce" :: String)         #-}
-{-# ANN svLazyIte ("HLint: ignore Eta reduce" :: String)         #-}
-{-# ANN module    ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore svIte     "Eta reduce"         -}
+{- HLint ignore svLazyIte "Eta reduce"         -}
+{- HLint ignore module    "Reduce duplication" -}

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -2268,7 +2268,7 @@ instance Show QueryContext where
    show QueryInternal = "Internal Query"
    show QueryExternal = "User Query"
 
-{-# ANN type FPOp ("HLint: ignore Use camelCase" :: String) #-}
-{-# ANN type PBOp ("HLint: ignore Use camelCase" :: String) #-}
-{-# ANN type OvOp ("HLint: ignore Use camelCase" :: String) #-}
-{-# ANN type NROp ("HLint: ignore Use camelCase" :: String) #-}
+{- HLint ignore type FPOp "Use camelCase" -}
+{- HLint ignore type PBOp "Use camelCase" -}
+{- HLint ignore type OvOp "Use camelCase" -}
+{- HLint ignore type NROp "Use camelCase" -}

--- a/Data/SBV/Either.hs
+++ b/Data/SBV/Either.hs
@@ -228,4 +228,4 @@ fromRight sab
         res st = do ms <- sbvToSV st sab
                     newExpr st kb (SBVApp (EitherAccess True) [ms])
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Data/SBV/Internals.hs
+++ b/Data/SBV/Internals.hs
@@ -136,7 +136,7 @@ buffer. We would like to hear if you do need these functions regularly so we can
 -- >>> prove $ \x -> fpIsNegativeZero x .|| sComparableSWord32AsSFloat (sFloatAsComparableSWord32 x) `fpIsEqualObject` x
 -- Q.E.D.
 sComparableSWord32AsSFloat :: SWord32 -> SFloat
-sComparableSWord32AsSFloat = CF.sComparableSWord32AsSFloat 
+sComparableSWord32AsSFloat = CF.sComparableSWord32AsSFloat
 
 -- | Inverse transformation to 'sDoubleAsComparableSWord64'. Note that this isn't a perfect inverse, since @-0@ maps to @0@ and back to @0@.
 -- Otherwise, it's faithful:
@@ -146,7 +146,7 @@ sComparableSWord32AsSFloat = CF.sComparableSWord32AsSFloat
 -- >>> prove $ \x -> fpIsNegativeZero x .|| sComparableSWord64AsSDouble (sDoubleAsComparableSWord64 x) `fpIsEqualObject` x
 -- Q.E.D.
 sComparableSWord64AsSDouble :: SWord64 -> SDouble
-sComparableSWord64AsSDouble = CF.sComparableSWord64AsSDouble 
+sComparableSWord64AsSDouble = CF.sComparableSWord64AsSDouble
 
 -- | Inverse transformation to 'sFloatingPointAsComparableSWord'. Note that this isn't a perfect inverse, since @-0@ maps to @0@ and back to @0@.
 -- Otherwise, it's faithful:
@@ -158,4 +158,4 @@ sComparableSWord64AsSDouble = CF.sComparableSWord64AsSDouble
 sComparableSWordAsSFloatingPoint :: forall eb sb. (KnownNat (eb + sb), BVIsNonZero (eb + sb), ValidFloat eb sb) => SWord (eb + sb) -> SFloatingPoint eb sb
 sComparableSWordAsSFloatingPoint = CF.sComparableSWordAsSFloatingPoint
 
-{-# ANN module ("HLint: ignore Use import/export shortcut" :: String) #-}
+{- HLint ignore module "Use import/export shortcut" -}

--- a/Data/SBV/Lambda.hs
+++ b/Data/SBV/Lambda.hs
@@ -67,7 +67,7 @@ inSubState inState comp = do
         --      It better be the case that in "toLambda" below, you do something with it.
         --
         -- Note the above applies to all the IORefs, which is most of the state, though
-        -- not all. For the time being, those are pathCond, stCfg, and startTime; which 
+        -- not all. For the time being, those are pathCond, stCfg, and startTime; which
         -- don't really impact anything.
         comp State {
                    -- These are not IORefs; so we share by copying  the value; changes won't be copied back
@@ -303,4 +303,4 @@ toLambda curProgInfo cfg expectedKind result@Result{resAsgns = SBVPgm asgnsSeq} 
                        tableMap   = IM.empty
                        funcMap    = M.empty
 
-{-# ANN module ("HLint: ignore Use second" :: String) #-}
+{- HLint ignore module "Use second" -}

--- a/Data/SBV/Provers/Prover.hs
+++ b/Data/SBV/Provers/Prover.hs
@@ -886,4 +886,4 @@ instance (SymVal a, SymVal b, SymVal c, SymVal d, SymVal e, SymVal f, SExecutabl
 instance (SymVal a, SymVal b, SymVal c, SymVal d, SymVal e, SymVal f, SymVal g, SExecutable m p) => SExecutable m ((SBV a, SBV b, SBV c, SBV d, SBV e, SBV f, SBV g) -> p) where
   sName k = mkArg >>= \a -> sName $ \b c d e f g -> k (a, b, c, d, e, f, g)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Data/SBV/String.hs
+++ b/Data/SBV/String.hs
@@ -439,4 +439,4 @@ isConcretelyEmpty :: SString -> Bool
 isConcretelyEmpty ss | Just s <- unliteral ss = P.null s
                      | True                   = False
 
-{-# ANN implode ("HLint: ignore Use concatMap" :: String) #-}
+{- HLint ignore implode "Use concatMap" -}

--- a/Data/SBV/Tools/Range.hs
+++ b/Data/SBV/Tools/Range.hs
@@ -210,4 +210,4 @@ rangesWith cfg prop = do mbBounds <- getInitialBounds
                                               Just xss -> search (xss ++ cs) sofar
                                     else search cs sofar
 
-{-# ANN rangesWith ("HLint: ignore Use fromMaybe" :: String) #-}
+{- HLint ignore rangesWith "Use fromMaybe" -}

--- a/Data/SBV/Tools/WeakestPreconditions.hs
+++ b/Data/SBV/Tools/WeakestPreconditions.hs
@@ -488,4 +488,4 @@ traceExecution Program{precondition, program, postcondition, stability} start = 
                            where mCur = currentMeasure is
                                  zero = map (const 0) mCur
 
-{-# ANN traceExecution ("HLint: ignore Use fromMaybe" :: String) #-}
+{- HLint ignore traceExecution "Use fromMaybe" -}

--- a/Data/SBV/Tuple.hs
+++ b/Data/SBV/Tuple.hs
@@ -433,4 +433,4 @@ instance ( SymVal a, Metric a
                         msMaximize (nm ++ "^._7") (p^._7)
                         msMaximize (nm ++ "^._8") (p^._8)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Data/SBV/Utils/SExpr.hs
+++ b/Data/SBV/Utils/SExpr.hs
@@ -621,4 +621,4 @@ makeHaskellFunction resp nm mbArgs
                 -- give up, and just do prefix!
                 app xs = unwords xs
 
-{-# ANN chainAssigns ("HLint: ignore Redundant if" :: String) #-}
+{- HLint ignore chainAssigns "Redundant if" -}

--- a/Documentation/SBV/Examples/BitPrecise/BrokenSearch.hs
+++ b/Documentation/SBV/Examples/BitPrecise/BrokenSearch.hs
@@ -108,4 +108,4 @@ checkCorrectMidValue f = prove $ do low  <- sInt32 "low"
 
                                     return $ sFromIntegral mid .== mid'
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Documentation/SBV/Examples/BitPrecise/Legato.hs
+++ b/Documentation/SBV/Examples/BitPrecise/Legato.hs
@@ -13,16 +13,16 @@
 -- Here's Legato's algorithm, as coded in Mostek assembly:
 --
 -- @
---    step1 :       LDX #8         ; load X immediate with the integer 8 
---    step2 :       LDA #0         ; load A immediate with the integer 0 
---    step3 : LOOP  ROR F1         ; rotate F1 right circular through C 
---    step4 :       BCC ZCOEF      ; branch to ZCOEF if C = 0 
---    step5 :       CLC            ; set C to 0 
---    step6 :       ADC F2         ; set A to A+F2+C and C to the carry 
---    step7 : ZCOEF ROR A          ; rotate A right circular through C 
---    step8 :       ROR LOW        ; rotate LOW right circular through C 
---    step9 :       DEX            ; set X to X-1 
---    step10:       BNE LOOP       ; branch to LOOP if Z = 0 
+--    step1 :       LDX #8         ; load X immediate with the integer 8
+--    step2 :       LDA #0         ; load A immediate with the integer 0
+--    step3 : LOOP  ROR F1         ; rotate F1 right circular through C
+--    step4 :       BCC ZCOEF      ; branch to ZCOEF if C = 0
+--    step5 :       CLC            ; set C to 0
+--    step6 :       ADC F2         ; set A to A+F2+C and C to the carry
+--    step7 : ZCOEF ROR A          ; rotate A right circular through C
+--    step8 :       ROR LOW        ; rotate LOW right circular through C
+--    step9 :       DEX            ; set X to X-1
+--    step10:       BNE LOOP       ; branch to LOOP if Z = 0
 -- @
 --
 -- This program came to be known as the Legato's challenge in the community, where
@@ -309,5 +309,5 @@ legatoInC = compileToC Nothing "runLegato" $ do
                 cgOutput "hi" hi
                 cgOutput "lo" lo
 
-{-# ANN legato ("HLint: ignore Redundant $" :: String)        #-}
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore legato "Redundant $"        -}
+{- HLint ignore module "Reduce duplication" -}

--- a/Documentation/SBV/Examples/Crypto/AES.hs
+++ b/Documentation/SBV/Examples/Crypto/AES.hs
@@ -56,7 +56,7 @@ type GF28 = SWord 8
 
 -- | Multiplication in GF(2^8). This is simple polynomial multiplication, followed
 -- by the irreducible polynomial @x^8+x^4+x^3+x^1+1@. We simply use the 'pMult'
--- function exported by SBV to do the operation. 
+-- function exported by SBV to do the operation.
 gf28Mult :: GF28 -> GF28 -> GF28
 gf28Mult x y = pMult (x, y, [8, 4, 3, 1, 0])
 
@@ -449,7 +449,7 @@ t256Dec = aesDecrypt ct ks
 -- @
 --   quickCheck aes128IsCorrect
 -- @
--- 
+--
 -- and get some degree of confidence in our code. Similar predicates can be easily constructed for 192, and
 -- 256 bit cases as well.
 aes128IsCorrect :: (SWord 32, SWord 32, SWord 32, SWord 32)  -- ^ plain-text words
@@ -594,5 +594,5 @@ hex8 :: (SymVal a, Show a, Integral a) => SBV a -> String
 hex8 v = replicate (8 - length s) '0' ++ s
   where s = flip showHex "" . fromJust . unliteral $ v
 
-{-# ANN aesRound    ("HLint: ignore Use head" :: String) #-}
-{-# ANN aesInvRound ("HLint: ignore Use head" :: String) #-}
+{- HLint ignore aesRound    "Use head" -}
+{- HLint ignore aesInvRound "Use head" -}

--- a/Documentation/SBV/Examples/Existentials/CRCPolynomial.hs
+++ b/Documentation/SBV/Examples/Existentials/CRCPolynomial.hs
@@ -79,4 +79,4 @@ genPoly hd maxCnt = do res <- allSatWith defaultSMTCfg{allSatMaxModelCount = Jus
 findHD4Polynomials :: Int -> IO ()
 findHD4Polynomials = genPoly 4
 
-{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}
+{- HLint ignore crc_48_16 "Use camelCase" -}

--- a/Documentation/SBV/Examples/Lists/BoundedMutex.hs
+++ b/Documentation/SBV/Examples/Lists/BoundedMutex.hs
@@ -163,4 +163,4 @@ notFair b = runSMT $ do p1    :: SList State   <- sList "p1"
                                                      io . putStrLn $ "P2: " ++ show p2V
                                                      io . putStrLn $ "Ts: " ++ show ts
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
+++ b/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
@@ -443,4 +443,4 @@ monad = do inp w
            mul y x
            add z y
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Documentation/SBV/Examples/Puzzles/Counts.hs
+++ b/Documentation/SBV/Examples/Puzzles/Counts.hs
@@ -83,4 +83,4 @@ counts = do res <- allSat $ puzzle `fmap` mkFreeVars 10
                      ++ ", of 8 is " ++ show (ns !! 8)
                      ++ ", of 9 is " ++ show (ns !! 9)
                      ++ "."
-{-# ANN counts ("HLint: ignore Use head" :: String) #-}
+{- HLint ignore counts "Use head" -}

--- a/Documentation/SBV/Examples/Queries/Concurrency.hs
+++ b/Documentation/SBV/Examples/Queries/Concurrency.hs
@@ -173,4 +173,4 @@ demoDependent = do
   results <- satConcurrentWithAll z3 [firstQuery v1 v2, secondQuery v2] (sharedDependent v1)
   print results
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/Documentation/SBV/Examples/Queries/Interpolants.hs
+++ b/Documentation/SBV/Examples/Queries/Interpolants.hs
@@ -126,4 +126,4 @@ evenOdd = do
 
        query $ getInterpolantZ3 [y .== 2*x, y .== 2*z+1]
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Arrays/InitVals.hs
+++ b/SBVTestSuite/TestSuite/Arrays/InitVals.hs
@@ -68,4 +68,4 @@ tests =
           t2 p goldFile = do r <- satWith defaultSMTCfg{verbose=True, redirectVerbose = Just goldFile} (constArr2 p)
                              appendFile goldFile ("\nFINAL OUTPUT:\n" ++ show r ++ "\n")
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Arrays/Query.hs
+++ b/SBVTestSuite/TestSuite/Arrays/Query.hs
@@ -153,4 +153,4 @@ q8 = query $ do x :: SArray Integer Integer <- freshArray "x" Nothing
 
                 pure (r1, r2)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/ArithNoSolver.hs
+++ b/SBVTestSuite/TestSuite/Basics/ArithNoSolver.hs
@@ -784,4 +784,4 @@ st = [(1, 2), (-1, -5), (0, 9), (5, 5)]
 
 sst :: [STuple Integer Integer]
 sst = map literal st
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/ArithSolver.hs
+++ b/SBVTestSuite/TestSuite/Basics/ArithSolver.hs
@@ -869,4 +869,4 @@ se = [Left 3, Right 5]
 st :: [(Integer, Integer)]
 st = [(1, 2), (-1, -5), (0, 9), (5, 5)]
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/Exceptions.hs
+++ b/SBVTestSuite/TestSuite/Basics/Exceptions.hs
@@ -65,4 +65,4 @@ z3Exc2 rf = do r <- runSMT z3ExcCatch `C.catch` \(e :: SBVException) -> return (
                         query $ do constrain $ x*y .== x*x
                                    show <$> checkSat
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/Lambda.hs
+++ b/SBVTestSuite/TestSuite/Basics/Lambda.hs
@@ -334,13 +334,13 @@ eval2 cArg1 cArg2 (sFun, cFun) rf = do m <- runSMTWith z3{verbose=True, redirect
                     _ -> error $ "Unexpected output: " P.++ show cs
 
 
-{-# ANN module ("HLint: ignore Use map once"   :: String) #-}
-{-# ANN module ("HLint: ignore Use sum"        :: String) #-}
-{-# ANN module ("HLint: ignore Fuse foldr/map" :: String) #-}
-{-# ANN module ("HLint: ignore Use zipWith"    :: String) #-}
-{-# ANN module ("HLint: ignore Use uncurry"    :: String) #-}
-{-# ANN module ("HLint: ignore Use even"       :: String) #-}
-{-# ANN module ("HLint: ignore Use odd"        :: String) #-}
-{-# ANN module ("HLint: ignore Use product"    :: String) #-}
-{-# ANN module ("HLint: ignore Avoid lambda"   :: String) #-}
-{-# ANN module ("HLint: ignore Eta reduce"     :: String) #-}
+{- HLint ignore module "Use map once"   -}
+{- HLint ignore module "Use sum"        -}
+{- HLint ignore module "Fuse foldr/map" -}
+{- HLint ignore module "Use zipWith"    -}
+{- HLint ignore module "Use uncurry"    -}
+{- HLint ignore module "Use even"       -}
+{- HLint ignore module "Use odd"        -}
+{- HLint ignore module "Use product"    -}
+{- HLint ignore module "Avoid lambda"   -}
+{- HLint ignore module "Eta reduce"     -}

--- a/SBVTestSuite/TestSuite/Basics/Quantifiers.hs
+++ b/SBVTestSuite/TestSuite/Basics/Quantifiers.hs
@@ -82,5 +82,5 @@ tests = testGroup "Basics.Quantifiers" $ concatMap mkGoal goals ++ concatMap mkP
          t2 A E act = pure $ quantifiedBool $ \(Forall x) (Exists y) -> act x y
          t2 A A act = pure $ quantifiedBool $ \(Forall x) (Forall y) -> act x y
 
-{-# ANN module ("HLint: ignore Reduce duplication"     :: String) #-}
-{-# ANN module ("HLint: ignore Unused LANGUAGE pragma" :: String) #-}
+{- HLint ignore module "Reduce duplication"     -}
+{- HLint ignore module "Unused LANGUAGE pragma" -}

--- a/SBVTestSuite/TestSuite/Basics/Set.hs
+++ b/SBVTestSuite/TestSuite/Basics/Set.hs
@@ -168,4 +168,4 @@ setOfTuples cfg = satWith cfg $ do
     y <- free_
     return $ x ./= y
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/Sum.hs
+++ b/SBVTestSuite/TestSuite/Basics/Sum.hs
@@ -142,4 +142,4 @@ sumMergeEither2 = do
 
    constrain $ isRight $ ite b x y
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Basics/Tuple.hs
+++ b/SBVTestSuite/TestSuite/Basics/Tuple.hs
@@ -147,5 +147,5 @@ unequal = do
                 Unsat -> return ()
                 _     -> error "did not expect this!"
 
-{-# ANN module ("HLint: ignore Use ."        :: String) #-}
-{-# ANN module ("HLint: ignore Redundant ^." :: String) #-}
+{- HLint ignore module "Use ."        -}
+{- HLint ignore module "Redundant ^." -}

--- a/SBVTestSuite/TestSuite/Basics/UISat.hs
+++ b/SBVTestSuite/TestSuite/Basics/UISat.hs
@@ -56,4 +56,4 @@ test3 = do setLogic Logic_ALL
            registerUISMTFunction q1
            registerUISMTFunction q2
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/CRC/CCITT_Unidir.hs
+++ b/SBVTestSuite/TestSuite/CRC/CCITT_Unidir.hs
@@ -60,4 +60,4 @@ crcUniGood hd sent received =
    where frameSent     = blastLE $ mkFrame sent
          frameReceived = blastLE $ mkFrame received
 
-{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}
+{- HLint ignore crc_48_16 "Use camelCase" -}

--- a/SBVTestSuite/TestSuite/CRC/GenPoly.hs
+++ b/SBVTestSuite/TestSuite/CRC/GenPoly.hs
@@ -59,5 +59,5 @@ crcGood hd divisor sent received =
 mkPoly :: SWord 16 -> SWord 64
 mkPoly d = 1 # d
 
-{-# ANN crc_48_16 ("HLint: ignore Use camelCase" :: String) #-}
-{-# ANN crcGoodE  ("HLint: ignore Use <$>"       :: String) #-}
+{- HLint ignore crc_48_16 "Use camelCase" -}
+{- HLint ignore crcGoodE  "Use <$>"       -}

--- a/SBVTestSuite/TestSuite/CRC/USB5.hs
+++ b/SBVTestSuite/TestSuite/CRC/USB5.hs
@@ -58,4 +58,4 @@ usbGood sent16 received16 =
          frameSent     = mkFrame sent
          frameReceived = mkFrame received
 
-{-# ANN crc_11_16 ("HLint: ignore Use camelCase" :: String) #-}
+{- HLint ignore crc_11_16 "Use camelCase" -}

--- a/SBVTestSuite/TestSuite/Char/Char.hs
+++ b/SBVTestSuite/TestSuite/Char/Char.hs
@@ -108,5 +108,5 @@ t11 = do x <- sInteger "x"
          c <- sChar "c"
          constrain $ L.length (cf4 x c) .== 1
 
-{-# ANN module ("HLint: ignore Use ."        :: String) #-}
-{-# ANN module ("HLint: ignore Redundant ^." :: String) #-}
+{- HLint ignore module "Use ."        -}
+{- HLint ignore module "Redundant ^." -}

--- a/SBVTestSuite/TestSuite/CodeGeneration/Floats.hs
+++ b/SBVTestSuite/TestSuite/CodeGeneration/Floats.hs
@@ -164,4 +164,4 @@ tests = testGroup "CodeGeneration.Floats" [
           , test1 "d_FP_IsPositive"         (fpIsPositive :: SDouble -> SBool)
           ]
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Optimization/Combined.hs
+++ b/SBVTestSuite/TestSuite/Optimization/Combined.hs
@@ -84,4 +84,4 @@ pareto3 = do x <- sInteger "x"
              minimize "min_x"            x
              maximize "max_x_plus_x"   $ x + x
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Optimization/ExtensionField.hs
+++ b/SBVTestSuite/TestSuite/Optimization/ExtensionField.hs
@@ -52,4 +52,4 @@ optExtField3 = do x <- sReal "x"
 
                   maximize "x_plus_y" $ x + y
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Optimization/Floats.hs
+++ b/SBVTestSuite/TestSuite/Optimization/Floats.hs
@@ -71,4 +71,4 @@ r = do x <- sFloat "x"
 
        minimize "metric-min-x+y" $ observe "min-x+y" (x+y)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Optimization/Quantified.hs
+++ b/SBVTestSuite/TestSuite/Optimization/Quantified.hs
@@ -75,4 +75,4 @@ q5 = do a <- sInteger "a"
         constrain $ b .>= 0
         minimize "goal" $ a+b
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Overflows/Arithmetic.hs
+++ b/SBVTestSuite/TestSuite/Overflows/Arithmetic.hs
@@ -239,4 +239,4 @@ overflow1 op cond = do x  <- free "x"
 
                        return $ overflowHappens `exactlyWhen` (extResult `svGreaterThan` toLarge (maxBound :: SBV a))
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Queries/Interpolants.hs
+++ b/SBVTestSuite/TestSuite/Queries/Interpolants.hs
@@ -94,4 +94,4 @@ q4 = do a <- sInteger "a"
                                  ,   a .== b .&& g c ./= g d
                                  ]
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Queries/Sums.hs
+++ b/SBVTestSuite/TestSuite/Queries/Sums.hs
@@ -174,4 +174,4 @@ querySumMergeEither2 = query $ do
    bv <- getValue b
    return (xv, yv, bv)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}

--- a/SBVTestSuite/TestSuite/Queries/Tuples.hs
+++ b/SBVTestSuite/TestSuite/Queries/Tuples.hs
@@ -64,5 +64,5 @@ queryTuples2 = do
        then return av
        else error $ "Didn't expect this: " ++ show av
 
-{-# ANN module ("HLint: ignore Use ."        :: String) #-}
-{-# ANN module ("HLint: ignore Redundant ^." :: String) #-}
+{- HLint ignore module "Use ."        -}
+{- HLint ignore module "Redundant ^." -}

--- a/SBVTestSuite/TestSuite/Queries/UISatEx.hs
+++ b/SBVTestSuite/TestSuite/Queries/UISatEx.hs
@@ -107,4 +107,4 @@ testQuery3 rf = do r <- runSMTWith defaultSMTCfg{verbose=True, redirectVerbose=J
 
 -- HLint complains about TypeApplications pragma, but if I remove it GHC complains
 -- I'm not sure who is right here; so ignore.
-{-# ANN module ("HLint: ignore Unused LANGUAGE pragma" :: String) #-}
+{- HLint ignore module "Unused LANGUAGE pragma" -}

--- a/SBVTestSuite/Utils/SBVTestFramework.hs
+++ b/SBVTestSuite/Utils/SBVTestFramework.hs
@@ -233,4 +233,4 @@ shouldNotTypeCheck a = do
       | True
       -> throwIO e
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{- HLint ignore module "Reduce duplication" -}


### PR DESCRIPTION
My primary motivation for this is cross-compiling SBV. Before this change, this wasn't possible due to the warning `Ignoring ANN annotation, because this is a stage-1 compiler without -fexternal-interpreter or doesn't support GHCi`, combined with `-Werror`. With the change, it's only blocked by #659.

Out of interest:
- Why `-Werror`? It's unusual to use it everywhere, and Hackage even bans uploading packages which enable it globally, which SBV appears to work around by enabling it in every individual file instead.
- What is this project's HLint policy? The `Data` folder is HLint-clean, but `Documentation` and `SBVTestSuite` contain some ignore pragmas but also trigger other hints which aren't ignored. Also, based on the numbers of HLint warnings which remain when all ignore pragmas are removed, many of them are redundant. Maybe putting the pragmas near use sites, as is conventional, would help see when these can be removed (although ideally HLint itself would be able to check this)