### PR TITLE
Fix SMTDefinable instances for 8-arg through 12-arg uninterpreted functions

### DIFF
--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -2611,7 +2611,7 @@ instance (SymVal i, SymVal h, SymVal g, SymVal f, SymVal e, SymVal d, SymVal c, 
                  result st = do isSMT <- inSMTMode st
                                 case (isSMT, uiKind) of
                                   (True, UICodeC (v, _)) -> sbvToSV st (v arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7)
-                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kh, kg, kf, ke, kd, kc, kb, ka, ki]) =<< retrieveUICode nm st ka uiKind
+                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [ki, kh, kg, kf, ke, kd, kc, kb, ka]) =<< retrieveUICode nm st ka uiKind
                                                                sw0 <- sbvToSV st arg0
                                                                sw1 <- sbvToSV st arg1
                                                                sw2 <- sbvToSV st arg2
@@ -2647,7 +2647,7 @@ instance (SymVal j, SymVal i, SymVal h, SymVal g, SymVal f, SymVal e, SymVal d, 
                  result st = do isSMT <- inSMTMode st
                                 case (isSMT, uiKind) of
                                   (True, UICodeC (v, _)) -> sbvToSV st (v arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8)
-                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kh, kg, kf, ke, kd, kc, kb, ka, ki, kj]) =<< retrieveUICode nm st ka uiKind
+                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kj, ki, kh, kg, kf, ke, kd, kc, kb, ka]) =<< retrieveUICode nm st ka uiKind
                                                                sw0 <- sbvToSV st arg0
                                                                sw1 <- sbvToSV st arg1
                                                                sw2 <- sbvToSV st arg2
@@ -2685,7 +2685,7 @@ instance (SymVal k, SymVal j, SymVal i, SymVal h, SymVal g, SymVal f, SymVal e, 
                  result st = do isSMT <- inSMTMode st
                                 case (isSMT, uiKind) of
                                   (True, UICodeC (v, _)) -> sbvToSV st (v arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9)
-                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kh, kg, kf, ke, kd, kc, kb, ka, ki, kj, kk]) =<< retrieveUICode nm st ka uiKind
+                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kk, kj, ki, kh, kg, kf, ke, kd, kc, kb, ka]) =<< retrieveUICode nm st ka uiKind
                                                                sw0 <- sbvToSV st arg0
                                                                sw1 <- sbvToSV st arg1
                                                                sw2 <- sbvToSV st arg2
@@ -2725,7 +2725,7 @@ instance (SymVal l, SymVal k, SymVal j, SymVal i, SymVal h, SymVal g, SymVal f, 
                  result st = do isSMT <- inSMTMode st
                                 case (isSMT, uiKind) of
                                   (True, UICodeC (v, _)) -> sbvToSV st (v arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10)
-                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kh, kg, kf, ke, kd, kc, kb, ka, ki, kj, kk, kl]) =<< retrieveUICode nm st ka uiKind
+                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kl, kk, kj, ki, kh, kg, kf, ke, kd, kc, kb, ka]) =<< retrieveUICode nm st ka uiKind
                                                                sw0  <- sbvToSV st arg0
                                                                sw1  <- sbvToSV st arg1
                                                                sw2  <- sbvToSV st arg2
@@ -2767,7 +2767,7 @@ instance (SymVal m, SymVal l, SymVal k, SymVal j, SymVal i, SymVal h, SymVal g, 
                  result st = do isSMT <- inSMTMode st
                                 case (isSMT, uiKind) of
                                   (True, UICodeC (v, _)) -> sbvToSV st (v arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11)
-                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [kh, kg, kf, ke, kd, kc, kb, ka, ki, kj, kk, kl, km]) =<< retrieveUICode nm st ka uiKind
+                                  _                      -> do newUninterpreted st (nm, mbArgs) (SBVType [km, kl, kk, kj, ki, kh, kg, kf, ke, kd, kc, kb, ka]) =<< retrieveUICode nm st ka uiKind
                                                                sw0  <- sbvToSV st arg0
                                                                sw1  <- sbvToSV st arg1
                                                                sw2  <- sbvToSV st arg2

--- a/SBVTestSuite/TestSuite/Uninterpreted/Function.hs
+++ b/SBVTestSuite/TestSuite/Uninterpreted/Function.hs
@@ -9,6 +9,12 @@
 -- Testsuite for Documentation.SBV.Examples.Uninterpreted.Function
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TemplateHaskell     #-}
+
 {-# OPTIONS_GHC -Wall -Werror #-}
 
 module TestSuite.Uninterpreted.Function(tests) where
@@ -17,98 +23,135 @@ import Documentation.SBV.Examples.Uninterpreted.Function
 
 import Utils.SBVTestFramework
 
-f1 :: SWord8 -> SBool
+data A1
+mkUninterpretedSort ''A1
+
+data A2
+mkUninterpretedSort ''A2
+
+data A3
+mkUninterpretedSort ''A3
+
+data A4
+mkUninterpretedSort ''A4
+
+data A5
+mkUninterpretedSort ''A5
+
+data A6
+mkUninterpretedSort ''A6
+
+data A7
+mkUninterpretedSort ''A7
+
+data A8
+mkUninterpretedSort ''A8
+
+data A9
+mkUninterpretedSort ''A9
+
+data A10
+mkUninterpretedSort ''A10
+
+data A11
+mkUninterpretedSort ''A11
+
+data A12
+mkUninterpretedSort ''A12
+
+
+f1 :: SA1 -> SBool
 f1 = uninterpret "f1"
 
-f2 :: SWord8 -> SWord8 -> SBool
+f2 :: SA1 -> SA2 -> SBool
 f2 = uninterpret "f2"
 
-f3 :: SWord8 -> SWord8 -> SWord8 -> SBool
+f3 :: SA1 -> SA2 -> SA3 -> SBool
 f3 = uninterpret "f3"
 
-f4 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f4 :: SA1 -> SA2 -> SA3 -> SA4 -> SBool
 f4 = uninterpret "f4"
 
-f5 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f5 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SBool
 f5 = uninterpret "f5"
 
-f6 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f6 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SBool
 f6 = uninterpret "f6"
 
-f7 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f7 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SBool
 f7 = uninterpret "f7"
 
-f8 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f8 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SBool
 f8 = uninterpret "f8"
 
-f9 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f9 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SBool
 f9 = uninterpret "f9"
 
-f10 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f10 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SBool
 f10 = uninterpret "f10"
 
-f11 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f11 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SA11 -> SBool
 f11 = uninterpret "f11"
 
-f12 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f12 :: SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SA11 -> SA12 -> SBool
 f12 = uninterpret "f12"
 
-thm1 :: SWord8 -> SWord8 -> SBool
+thm1 :: SA1 -> SA1 -> SBool
 thm1 x a1 =
   x .== a1
   .=> f1 x .== f1 a1
 
-thm2 :: SWord8 -> SWord8 -> SWord8 -> SBool
+thm2 :: SA1 -> SA1 -> SA2 -> SBool
 thm2 x a1 a2 =
   x .== a1
   .=> f2 x a2 .== f2 a1 a2
 
-thm3 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm3 :: SA1 -> SA1 -> SA2 -> SA3 -> SBool
 thm3 x a1 a2 a3 =
   x .== a1
   .=> f3 x a2 a3 .== f3 a1 a2 a3
 
-thm4 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm4 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SBool
 thm4 x a1 a2 a3 a4 =
   x .== a1
   .=> f4 x a2 a3 a4 .== f4 a1 a2 a3 a4
 
-thm5 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm5 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SBool
 thm5 x a1 a2 a3 a4 a5 =
   x .== a1
   .=> f5 x a2 a3 a4 a5 .== f5 a1 a2 a3 a4 a5
 
-thm6 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm6 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SBool
 thm6 x a1 a2 a3 a4 a5 a6 =
   x .== a1
   .=> f6 x a2 a3 a4 a5 a6 .== f6 a1 a2 a3 a4 a5 a6
 
-thm7 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm7 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SBool
 thm7 x a1 a2 a3 a4 a5 a6 a7 =
   x .== a1
   .=> f7 x a2 a3 a4 a5 a6 a7 .== f7 a1 a2 a3 a4 a5 a6 a7
 
-thm8 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm8 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SBool
 thm8 x a1 a2 a3 a4 a5 a6 a7 a8 =
   x .== a1
   .=> f8 x a2 a3 a4 a5 a6 a7 a8 .== f8 a1 a2 a3 a4 a5 a6 a7 a8
 
-thm9 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm9 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SBool
 thm9 x a1 a2 a3 a4 a5 a6 a7 a8 a9 =
   x .== a1
   .=> f9 x a2 a3 a4 a5 a6 a7 a8 a9 .== f9 a1 a2 a3 a4 a5 a6 a7 a8 a9
 
-thm10 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm10 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SBool
 thm10 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 =
   x .== a1
   .=> f10 x a2 a3 a4 a5 a6 a7 a8 a9 a10 .== f10 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10
 
-thm11 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm11 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SA11 -> SBool
 thm11 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 =
   x .== a1
   .=> f11 x a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 .== f11 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11
 
-thm12 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm12 :: SA1 -> SA1 -> SA2 -> SA3 -> SA4 -> SA5 -> SA6 -> SA7 -> SA8 -> SA9 -> SA10 -> SA11 -> SA12 -> SBool
 thm12 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 =
   x .== a1
   .=> f12 x a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 .== f12 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12

--- a/SBVTestSuite/TestSuite/Uninterpreted/Function.hs
+++ b/SBVTestSuite/TestSuite/Uninterpreted/Function.hs
@@ -17,8 +17,116 @@ import Documentation.SBV.Examples.Uninterpreted.Function
 
 import Utils.SBVTestFramework
 
+f1 :: SWord8 -> SBool
+f1 = uninterpret "f1"
+
+f2 :: SWord8 -> SWord8 -> SBool
+f2 = uninterpret "f2"
+
+f3 :: SWord8 -> SWord8 -> SWord8 -> SBool
+f3 = uninterpret "f3"
+
+f4 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f4 = uninterpret "f4"
+
+f5 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f5 = uninterpret "f5"
+
+f6 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f6 = uninterpret "f6"
+
+f7 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f7 = uninterpret "f7"
+
+f8 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f8 = uninterpret "f8"
+
+f9 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f9 = uninterpret "f9"
+
+f10 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f10 = uninterpret "f10"
+
+f11 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f11 = uninterpret "f11"
+
+f12 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+f12 = uninterpret "f12"
+
+thm1 :: SWord8 -> SWord8 -> SBool
+thm1 x a1 =
+  x .== a1
+  .=> f1 x .== f1 a1
+
+thm2 :: SWord8 -> SWord8 -> SWord8 -> SBool
+thm2 x a1 a2 =
+  x .== a1
+  .=> f2 x a2 .== f2 a1 a2
+
+thm3 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm3 x a1 a2 a3 =
+  x .== a1
+  .=> f3 x a2 a3 .== f3 a1 a2 a3
+
+thm4 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm4 x a1 a2 a3 a4 =
+  x .== a1
+  .=> f4 x a2 a3 a4 .== f4 a1 a2 a3 a4
+
+thm5 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm5 x a1 a2 a3 a4 a5 =
+  x .== a1
+  .=> f5 x a2 a3 a4 a5 .== f5 a1 a2 a3 a4 a5
+
+thm6 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm6 x a1 a2 a3 a4 a5 a6 =
+  x .== a1
+  .=> f6 x a2 a3 a4 a5 a6 .== f6 a1 a2 a3 a4 a5 a6
+
+thm7 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm7 x a1 a2 a3 a4 a5 a6 a7 =
+  x .== a1
+  .=> f7 x a2 a3 a4 a5 a6 a7 .== f7 a1 a2 a3 a4 a5 a6 a7
+
+thm8 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm8 x a1 a2 a3 a4 a5 a6 a7 a8 =
+  x .== a1
+  .=> f8 x a2 a3 a4 a5 a6 a7 a8 .== f8 a1 a2 a3 a4 a5 a6 a7 a8
+
+thm9 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm9 x a1 a2 a3 a4 a5 a6 a7 a8 a9 =
+  x .== a1
+  .=> f9 x a2 a3 a4 a5 a6 a7 a8 a9 .== f9 a1 a2 a3 a4 a5 a6 a7 a8 a9
+
+thm10 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm10 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 =
+  x .== a1
+  .=> f10 x a2 a3 a4 a5 a6 a7 a8 a9 a10 .== f10 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10
+
+thm11 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm11 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 =
+  x .== a1
+  .=> f11 x a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 .== f11 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11
+
+thm12 :: SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SWord8 -> SBool
+thm12 x a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 =
+  x .== a1
+  .=> f12 x a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 .== f12 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12
+
 tests :: TestTree
 tests =
   testGroup "Uninterpreted.Function"
   [ testCase "aufunc-0" (assertIsThm thmGood)
+  , testCase "aufunc-1" (assertIsThm thm1)
+  , testCase "aufunc-2" (assertIsThm thm2)
+  , testCase "aufunc-3" (assertIsThm thm3)
+  , testCase "aufunc-4" (assertIsThm thm4)
+  , testCase "aufunc-5" (assertIsThm thm5)
+  , testCase "aufunc-6" (assertIsThm thm6)
+  , testCase "aufunc-7" (assertIsThm thm7)
+  , testCase "aufunc-8" (assertIsThm thm8)
+  , testCase "aufunc-9" (assertIsThm thm9)
+  , testCase "aufunc-10" (assertIsThm thm10)
+  , testCase "aufunc-11" (assertIsThm thm11)
+  , testCase "aufunc-12" (assertIsThm thm12)
   ]


### PR DESCRIPTION
The `SMTDefinable` instances for 8-arg through 12-arg uninterpreted functions feed arguments to the `newUninterpreted` function in the wrong order. The result is that, when such functions are used in a solver query, the solver returns an error at runtime.

For example, when using a function that takes arguments of types A1-A8 and returns Bool:

```
Exception:
*** Data.SBV: Unexpected non-success response from Z3:
***
***    Sent      : (define-fun s10 () Bool (f8 s0 s2 s3 s4 s5 s6 s7 s8))
***    Expected  : success
***    Received  : (error "line 34 column 51: unknown constant f8 (A1 A2 A3 A4 A5 A6 A7 A8)
***                declared: (declare-fun f8 (A2 A3 A4 A5 A6 A7 A8 Bool) A1) ")
***
***    Exit code : ExitFailure (-15)
***    Executable: /home/octal/.nix-profile/bin/z3
***    Options   : -nw -in -smt2
***
***    Reason    : Check solver response for further information. If your code is correct,
***                please report this as an issue either with SBV or the solver itself!

Use -p '/Uninterpreted.Function/&&/aufunc-8/' to rerun this test only.
```

This PR adds simple tests for uninterpreted functions that catch this error, and fixes the 8-arg through 12-arg instances.

Thanks so much for adding the higher-argument function instances I asked about in #670! I just now got back to what I needed them for, and encountered this bug, but it was an easy fix.