### PR TITLE
Fix the zombie solver processes mentioned in #477

### DIFF
--- a/Data/SBV/Control/Utils.hs
+++ b/Data/SBV/Control/Utils.hs
@@ -38,6 +38,7 @@ module Data.SBV.Control.Utils (
      , timeout, queryDebug, retrieveResponse, recoverKindedValue, runProofOn, executeQuery
      ) where
 
+import Control.Exception (finally)
 import Data.List  (sortBy, sortOn, elemIndex, partition, groupBy, tails, intercalate, nub, sort, isPrefixOf, isSuffixOf)
 
 import Data.Char      (isPunctuation, isSpace, isDigit)
@@ -1898,7 +1899,12 @@ executeQuery queryContext (QueryT userQuery) = do
 
                   liftIO $ writeIORef (runMode st) $ SMTMode qc IRun isSAT cfg
 
-                  lift $ join $ liftIO $ backend cfg' st (show pgm) $ extractIO . runReaderT userQuery
+                  lift $ join $ liftIO $
+                    finally (extractIO $ join $ liftIO $ backend cfg' st (show pgm) $ extractIO . runReaderT userQuery) $ do
+                      qs <- readIORef $ rQueryState st
+                      case qs of
+                        Nothing                         -> return ()
+                        Just QueryState{queryTerminate} -> queryTerminate
 
         -- Already in a query, in theory we can just continue, but that causes use-case issues
         -- so we reject it. TODO: Review if we should actually support this. The issue arises with

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -1967,13 +1967,6 @@ runSymbolicInState st (SymbolicT c) = do
                  = contextMismatchError (sbvContext st) ctx Nothing Nothing
 
    mapM_ check $ nub $ G.universeBi res
-
-   -- Clean-up after ourselves
-   qs <- liftIO $ readIORef $ rQueryState st
-   case qs of
-     Nothing                         -> return ()
-     Just QueryState{queryTerminate} -> liftIO queryTerminate
-
    return (r, res)
 
 -- | Grab the program from a running symbolic simulation state.

--- a/Data/SBV/Utils/ExtractIO.hs
+++ b/Data/SBV/Utils/ExtractIO.hs
@@ -32,7 +32,7 @@ class MonadIO m => ExtractIO m where
 
 -- | Trivial IO extraction for 'IO'.
 instance ExtractIO IO where
-    extractIO = pure
+    extractIO = fmap pure
 
 -- | IO extraction for 'MaybeT'.
 instance ExtractIO m => ExtractIO (MaybeT m) where


### PR DESCRIPTION
I encountered the same issue as mentioned in #477, and this pull request tries to fix it. I do not fully understand the codebase, so please carefully review my changes.

I believe that the root cause of the issue is that the `queryTerminate` (i.e., the `cleanUp` function defined in `runSolver`) is skipped when an exception happens before it but after the solver has been started by the `runSolver` call.

This pull request moves the termination of the solver to `executeQuery` function, and terminates it immediately after we finished all the interaction with the solver. In this function, we have the handy `ExtractIO` class, which allows us to do the clean up no matter whether an exception is raised with `finally`.

The `ExtractIO` instance for `IO` is also buggy, though. It violates the law mentioned in the comment. This pull request also fixes it, and the fix is required for the clean up to work.
https://github.com/LeventErkok/sbv/blob/ddd2c87f280e3bd29d1115b388282ec3a9b2647b/Data/SBV/Utils/ExtractIO.hs#L29-L31

After doing these changes, I observed no zombie or long-running processes after killing a thread running sbv.