### PR TITLE
Try to fix the zombie solver processes, don't hide the exceptions

### DIFF
--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -89,6 +89,7 @@ import GHC.Stack
 import GHC.Stack.Types
 import GHC.Generics (Generic)
 
+import qualified Control.Exception as C
 import qualified Control.Monad.State.Lazy    as LS
 import qualified Control.Monad.State.Strict  as SS
 import qualified Control.Monad.Writer.Lazy   as LW
@@ -778,7 +779,7 @@ data QueryState = QueryState { queryAsk                 :: Maybe Int -> String -
                              , querySend                :: Maybe Int -> String -> IO ()
                              , queryRetrieveResponse    :: Maybe Int -> IO String
                              , queryConfig              :: SMTConfig
-                             , queryTerminate           :: IO ()
+                             , queryTerminate           :: Maybe C.SomeException -> IO ()
                              , queryTimeOutValue        :: Maybe Int
                              , queryAssertionStackDepth :: Int
                              }
@@ -1967,12 +1968,6 @@ runSymbolicInState st (SymbolicT c) = do
                  = contextMismatchError (sbvContext st) ctx Nothing Nothing
 
    mapM_ check $ nub $ G.universeBi res
-
-   -- Clean-up after ourselves
-   qs <- liftIO $ readIORef $ rQueryState st
-   case qs of
-     Nothing                         -> return ()
-     Just QueryState{queryTerminate} -> liftIO queryTerminate
 
    return (r, res)
 

--- a/Data/SBV/Utils/ExtractIO.hs
+++ b/Data/SBV/Utils/ExtractIO.hs
@@ -32,7 +32,7 @@ class MonadIO m => ExtractIO m where
 
 -- | Trivial IO extraction for 'IO'.
 instance ExtractIO IO where
-    extractIO = pure
+    extractIO = fmap pure
 
 -- | IO extraction for 'MaybeT'.
 instance ExtractIO m => ExtractIO (MaybeT m) where


### PR DESCRIPTION
This pull request is another attempt to fix the zombie solver processes mentioned in #477. Previously, a pull request has been sent as #691, and has been reverted in #693, as it introduced test failures where the error messages for the exceptions are hidden by a generic failure message, as discussed in #694.

The reason why that happened is that `finally` swallows the exception, and the `queryTerminate` being called in the `finally` clause throws the generic failure message.

In addition to the fix in #691, this pull request tunes the `queryTerminate` function with an additional `Maybe SomeException` argument. The abnormal termination path will now pass the exceptions to the `queryTerminate` and let the function forward the exception.

There are hard-coded paths for the solvers in the golden files, and the test suite requires all kinds of solvers to be installed, so I only ensured that

- this version passes `exceptionRemote1`, and
- this version only differs by the path for `exceptionLocal2`, and
- this version correctly kills the long-running or zombie processes.

Please run the full test suite in your environment to ensure that it works.