### PR TITLE
OptimizeStyle: add type parameter for the optimize result type

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -371,7 +371,8 @@ module Data.SBV (
 
   -- ** Multiple optimization goals
   -- $multiOpt
-  , OptimizeStyle(..)
+  , BaseIO.OptimizeStyle
+  , lexicographic, independent, pareto
   -- ** Objectives and Metrics
   , Objective(..)
   , Metric(..), minimize, maximize
@@ -387,7 +388,8 @@ module Data.SBV (
 
   -- ** Inspecting proof results
   -- $resultTypes
-  , ThmResult(..), SatResult(..), AllSatResult(..), SafeResult(..), OptimizeResult(..), SMTResult(..), SMTReasonUnknown(..)
+  , ThmResult(..), SatResult(..), AllSatResult(..), SafeResult(..), OptimizeResult, SMTResult(..), SMTReasonUnknown(..)
+  , LexicographicResult(..), IndependentResult(..), ParetoResult(..)
 
   -- ** Observing expressions
   -- $observeInternal
@@ -473,7 +475,7 @@ import Data.SBV.Provers.Prover hiding (prove, proveWith, sat, satWith, allSat,
 import Data.IORef (modifyIORef', readIORef)
 
 import Data.SBV.Client
-import Data.SBV.Client.BaseIO
+import Data.SBV.Client.BaseIO as BaseIO
 
 import Data.SBV.Utils.TDiff (Timing(..))
 

--- a/Data/SBV/Client/BaseIO.hs
+++ b/Data/SBV/Client/BaseIO.hs
@@ -33,12 +33,11 @@ import Data.SBV.Core.Data      (HasKind, Kind, Outputtable, Penalty, SymArray,
 import Data.SBV.Core.Sized     (IntN, WordN)
 import Data.SBV.Core.Kind      (BVIsNonZero, ValidFloat)
 import Data.SBV.Core.Model     (Metric(..), SymTuple)
-import Data.SBV.Core.Symbolic  (Objective, OptimizeStyle, Result, VarContext, Symbolic, SBVRunMode, SMTConfig,
+import Data.SBV.Core.Symbolic  (Objective, Result, VarContext, Symbolic, SBVRunMode, SMTConfig,
                                 SVal, symbolicEnv, rPartitionVars, State(..))
 import Data.SBV.Control.Types  (SMTOption)
-import Data.SBV.Provers.Prover (Provable, Satisfiable, SExecutable, ThmResult)
-import Data.SBV.SMT.SMT        (AllSatResult, SafeResult, SatResult,
-                                OptimizeResult)
+import Data.SBV.Provers.Prover (Provable, Satisfiable, SExecutable, ThmResult, OptimizeResult)
+import Data.SBV.SMT.SMT        (AllSatResult, SafeResult, SatResult)
 
 import GHC.TypeLits (KnownNat, TypeError, ErrorMessage(..))
 import Data.Kind
@@ -126,16 +125,18 @@ allSat = Trans.allSat
 allSatWith :: Satisfiable a => SMTConfig -> a -> IO AllSatResult
 allSatWith = Trans.allSatWith
 
+type OptimizeStyle = Trans.OptimizeStyle IO
+
 -- | Optimize a given collection of `Objective`s.
 --
 -- NB. For a version which generalizes over the underlying monad, see 'Data.SBV.Trans.optimize'
-optimize :: Satisfiable a => OptimizeStyle -> a -> IO OptimizeResult
+optimize :: (OptimizeResult result, Satisfiable a) => OptimizeStyle result -> a -> IO result
 optimize = Trans.optimize
 
 -- | Optimizes the objectives using the given SMT-solver.
 --
 -- NB. For a version which generalizes over the underlying monad, see 'Data.SBV.Trans.optimizeWith'
-optimizeWith :: Satisfiable a => SMTConfig -> OptimizeStyle -> a -> IO OptimizeResult
+optimizeWith :: (OptimizeResult result, Satisfiable a) => SMTConfig -> OptimizeStyle result -> a -> IO result
 optimizeWith = Trans.optimizeWith
 
 -- | Check if the constraints given are consistent in a prove call using the default solver.

--- a/Data/SBV/Core/Data.hs
+++ b/Data/SBV/Core/Data.hs
@@ -61,7 +61,7 @@ module Data.SBV.Core.Data
  , SolverCapabilities(..)
  , extractSymbolicSimulationState
  , SMTScript(..), Solver(..), SMTSolver(..), SMTResult(..), SMTModel(..), SMTConfig(..)
- , OptimizeStyle(..), Penalty(..), Objective(..)
+ , Penalty(..), Objective(..)
  , QueryState(..), QueryT(..), SMTProblem(..), Constraint(..), Lambda(..), Forall(..), Exists(..), ExistsUnique(..), ForallN(..), ExistsN(..)
  , QuantifiedBool(..), EqSymbolic(..), QNot(..), Skolemize(skolemize, taggedSkolemize)
  , bvExtract, (#), bvDrop, bvTake

--- a/Data/SBV/Core/Symbolic.hs
+++ b/Data/SBV/Core/Symbolic.hs
@@ -59,7 +59,7 @@ module Data.SBV.Core.Symbolic
   , SMTLibPgm(..), SMTLibVersion(..), smtLibVersionExtension
   , SolverCapabilities(..)
   , extractSymbolicSimulationState, CnstMap
-  , OptimizeStyle(..), Objective(..), Penalty(..), objectiveName, addSValOptGoal
+  , Objective(..), Penalty(..), objectiveName, addSValOptGoal
   , MonadQuery(..), QueryT(..), Query, Queriable(..), Fresh(..), QueryState(..), QueryContext(..)
   , SMTScript(..), Solver(..), SMTSolver(..), SMTResult(..), SMTModel(..), SMTConfig(..), SMTEngine
   , validationRequested, outputSVal, ProgInfo(..), mustIgnoreVar, getRootState
@@ -744,16 +744,6 @@ getUserName (NamedSymVar _ nm) = nm
 getUserName' :: NamedSymVar -> String
 getUserName' = T.unpack . getUserName
 
--- | Style of optimization. Note that in the pareto case the user is allowed
--- to specify a max number of fronts to query the solver for, since there might
--- potentially be an infinite number of them and there is no way to know exactly
--- how many ahead of time. If 'Nothing' is given, SBV will possibly loop forever
--- if the number is really infinite.
-data OptimizeStyle = Lexicographic      -- ^ Objectives are optimized in the order given, earlier objectives have higher priority.
-                   | Independent        -- ^ Each objective is optimized independently.
-                   | Pareto (Maybe Int) -- ^ Objectives are optimized according to pareto front: That is, no objective can be made better without making some other worse.
-                   deriving (Eq, Show)
-
 -- | Penalty for a soft-assertion. The default penalty is @1@, with all soft-assertions belonging
 -- to the same objective goal. A positive weight and an optional group can be provided by using
 -- the 'Penalty' constructor.
@@ -844,9 +834,6 @@ type Query = QueryT IO
 
 instance MonadSymbolic Query where
    symbolicEnv = queryState
-
-instance NFData OptimizeStyle where
-   rnf x = x `seq` ()
 
 instance NFData Penalty where
    rnf DefaultPenalty  = ()

--- a/Data/SBV/Dynamic.hs
+++ b/Data/SBV/Dynamic.hs
@@ -87,7 +87,7 @@ module Data.SBV.Dynamic
   -- * Model extraction
 
   -- ** Inspecting proof results
-  , ThmResult(..), SatResult(..), AllSatResult(..), SafeResult(..), OptimizeResult(..), SMTResult(..)
+  , ThmResult(..), SatResult(..), AllSatResult(..), SafeResult(..), OptimizeResult, SMTResult(..)
 
   -- ** Programmable model extraction
   , genParse, getModelAssignment, getModelDictionary
@@ -144,8 +144,8 @@ import Data.SBV.Compilers.CodeGen ( SBVCodeGen
                                   )
 import Data.SBV.Compilers.C       (compileToC, compileToCLib)
 
-import Data.SBV.Provers.Prover (boolector, bitwuzla, cvc4, cvc5, dReal, yices, z3, mathSAT, abc, defaultSMTCfg)
-import Data.SBV.SMT.SMT        (ThmResult(..), SatResult(..), SafeResult(..), OptimizeResult(..), AllSatResult(..), genParse)
+import Data.SBV.Provers.Prover (OptimizeResult, boolector, bitwuzla, cvc4, cvc5, dReal, yices, z3, mathSAT, abc, defaultSMTCfg)
+import Data.SBV.SMT.SMT        (ThmResult(..), SatResult(..), SafeResult(..), AllSatResult(..), genParse)
 import Data.SBV                (sbvCheckSolverInstallation, defaultSolverConfig, getAvailableSolvers)
 
 import qualified Data.SBV                as SBV (SBool, proveWithAll, proveWithAny, satWithAll, satWithAny

--- a/Data/SBV/Tools/Range.hs
+++ b/Data/SBV/Tools/Range.hs
@@ -146,7 +146,7 @@ rangesWith cfg prop = do mbBounds <- getInitialBounds
 
 
                 getBound cstr = do let objName = "boundValue"
-                                   res@(LexicographicResult m) <- optimizeWith cfg Lexicographic $ do x <- free_
+                                   res@(LexicographicResult m) <- optimizeWith cfg lexicographic $ do x <- free_
                                                                                                       constrain $ prop x
                                                                                                       cstr objName x
                                    case m of

--- a/Data/SBV/Trans.hs
+++ b/Data/SBV/Trans.hs
@@ -118,7 +118,10 @@ module Data.SBV.Trans (
   -- * Optimization
 
   -- ** Multiple optimization goals
-  , OptimizeStyle(..)
+  , OptimizeStyle
+  , lexicographic
+  , independent
+  , pareto
   -- ** Objectives
   , Objective(..)
   -- ** Soft assumptions

--- a/Documentation/SBV/Examples/Misc/Floating.hs
+++ b/Documentation/SBV/Examples/Misc/Floating.hs
@@ -218,8 +218,8 @@ roundingAdd = sat $ do m :: SRoundingMode <- free "rm"
 -- decimal notation one should be very careful about the printed representation and the numeric value; while
 -- they will match in value (if there are no bugs!), they can print quite differently! (Also keep in
 -- mind the rounding modes that impact how the conversion is done.)
-fp54Bounds :: IO OptimizeResult
-fp54Bounds = optimize Independent $ do x :: SFloatingPoint 5 4 <- sFloatingPoint "x"
+fp54Bounds :: IO IndependentResult
+fp54Bounds = optimize independent $ do x :: SFloatingPoint 5 4 <- sFloatingPoint "x"
 
                                        constrain $ fpIsPoint x
                                        constrain $ x .> 0

--- a/Documentation/SBV/Examples/Optimization/Enumerate.hs
+++ b/Documentation/SBV/Examples/Optimization/Enumerate.hs
@@ -63,8 +63,8 @@ isWeekend = (`sElem` weekend)
 -- Optimal model:
 --   almostWeekend = Fri :: Day
 --   last-day      =   4 :: Word8
-almostWeekend :: IO OptimizeResult
-almostWeekend = optimize Lexicographic $ do
+almostWeekend :: IO LexicographicResult
+almostWeekend = optimize lexicographic $ do
                     day <- free "almostWeekend"
                     constrain $ sNot (isWeekend day)
                     maximize "last-day" day
@@ -76,8 +76,8 @@ almostWeekend = optimize Lexicographic $ do
 -- Optimal model:
 --   weekendJustOver = Mon :: Day
 --   first-day       =   0 :: Word8
-weekendJustOver :: IO OptimizeResult
-weekendJustOver = optimize Lexicographic $ do
+weekendJustOver :: IO LexicographicResult
+weekendJustOver = optimize lexicographic $ do
                       day <- free "weekendJustOver"
                       constrain $ sNot (isWeekend day)
                       minimize "first-day" day
@@ -89,8 +89,8 @@ weekendJustOver = optimize Lexicographic $ do
 -- Optimal model:
 --   firstWeekend  = Sat :: Day
 --   first-weekend =   5 :: Word8
-firstWeekend :: IO OptimizeResult
-firstWeekend = optimize Lexicographic $ do
+firstWeekend :: IO LexicographicResult
+firstWeekend = optimize lexicographic $ do
                       day <- free "firstWeekend"
                       constrain $ isWeekend day
                       minimize "first-weekend" day

--- a/Documentation/SBV/Examples/Optimization/ExtField.hs
+++ b/Documentation/SBV/Examples/Optimization/ExtField.hs
@@ -25,7 +25,7 @@ import Data.SBV
 --
 -- We have:
 --
--- >>> optimize Independent problem
+-- >>> optimize independent problem
 -- Objective "one-x": Optimal in an extension field:
 --   one-x =  oo :: Integer
 --   min_y = 7.0 :: Real

--- a/Documentation/SBV/Examples/Optimization/LinearOpt.hs
+++ b/Documentation/SBV/Examples/Optimization/LinearOpt.hs
@@ -30,7 +30,7 @@ import Data.SBV
 --          4. x1 >= 0
 --          5. x2 >= 0
 --
--- >>> optimize Lexicographic problem
+-- >>> optimize lexicographic problem
 -- Optimal model:
 --   x1   =  47 % 9 :: Real
 --   x2   =  20 % 9 :: Real

--- a/Documentation/SBV/Examples/Optimization/Production.hs
+++ b/Documentation/SBV/Examples/Optimization/Production.hs
@@ -43,7 +43,7 @@ import Data.SBV
 --
 -- We have:
 --
--- >>> optimize Lexicographic production
+-- >>> optimize lexicographic production
 -- Optimal model:
 --   X     = 45 :: Integer
 --   Y     =  6 :: Integer

--- a/Documentation/SBV/Examples/Optimization/VM.hs
+++ b/Documentation/SBV/Examples/Optimization/VM.hs
@@ -33,7 +33,7 @@ import Data.SBV
 --
 -- We have:
 --
--- >>> optimize Lexicographic allocate
+-- >>> optimize lexicographic allocate
 -- Optimal model:
 --   x11         = False :: Bool
 --   x12         = False :: Bool

--- a/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
+++ b/Documentation/SBV/Examples/Puzzles/AOC_2021_24.hs
@@ -161,7 +161,7 @@ run pgm = ST.execStateT pgm initState
 --   Minimum model number = 91811241911641 :: Int64
 -- @
 puzzle :: Bool -> IO ()
-puzzle shouldMaximize = print =<< optimizeWith z3{isNonModelVar = (/= finalVar)}  Lexicographic problem
+puzzle shouldMaximize = print =<< optimizeWith z3{isNonModelVar = (/= finalVar)}  lexicographic problem
   where finalVar | shouldMaximize = "Maximum model number"
                  | True           = "Minimum model number"
         problem = do State{env, inputs} <- run monad


### PR DESCRIPTION
OptimizeResult: split into types LexicographicResult, ParetoResult, IndependentResult
Made OptimizeResult a type class.
Requires moving definition of OptimizeStyle to Provers.Prover.