### PR TITLE
Adjusted `constArray` to create an array literal when given a non-symbolic constant.

### DIFF
--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -3253,10 +3253,14 @@ writeArray array key value
 
 -- | Create a constant array. This is a special case of 'lambdaArray', but it creates a
 -- simpler expression in the case of constants.
-constArray :: forall a b. (SymVal a, HasKind b) => SBV b -> SArray a b
-constArray v = SBV . SVal k . Right $ cache g
-  where ka = kindOf (Proxy @a)
-        kb = kindOf (Proxy @b)
+constArray :: forall key val. (SymVal key, SymVal val) => SBV val -> SArray key val
+constArray v
+  | Just v' <- unliteral v
+  = literal $ ArrayModel [] v'
+  | True
+  = SBV . SVal k . Right $ cache g
+  where ka = kindOf (Proxy @key)
+        kb = kindOf (Proxy @val)
         k  = KArray ka kb
 
         g st = do sv <- sbvToSV st v


### PR DESCRIPTION
Here's a small optimization to `constArray` that follows suit of `writeArray` where if the arguments are literals we can just use `ArrayModel` instead of instantiating a symbolic value. I noticed that my implementation for #760 had this, so I thought it would be good to push this portion still!