### PR TITLE
Fix golden tests failing due to binary path not matching

### DIFF
--- a/Data/SBV/SMT/SMT.hs
+++ b/Data/SBV/SMT/SMT.hs
@@ -61,6 +61,7 @@ import Data.Either (rights)
 import System.Directory   (findExecutable)
 import System.Environment (getEnv)
 import System.Exit        (ExitCode(..))
+import System.FilePath    (takeBaseName)
 import System.IO          (hClose, hFlush, hPutStrLn, hGetContents, hGetLine, hReady, hGetChar)
 import System.Process     (runInteractiveProcess, waitForProcess, terminateProcess)
 
@@ -713,7 +714,7 @@ standardSolver :: SMTConfig       -- ^ The current configuration
 standardSolver config ctx pgm continuation = do
     let msg s    = debug config ["** " ++ s]
         smtSolver= solver config
-        exec     = executable smtSolver
+        exec     = takeBaseName (executable smtSolver)
         opts     = options smtSolver config ++ extraArgs config
     msg $ "Calling: "  ++ (exec ++ (if null opts then "" else " ") ++ joinArgs opts)
     rnf pgm `seq` pipeProcess config ctx exec opts pgm continuation


### PR DESCRIPTION
Golden tests fail incorrectly on NixOS due to the executable being `/nix/store/.../bin/z3`

This should also make it more robust on Windows due to file extensions.

A backport to v11 might be good to as that's still the latest version available on the latest [stackage LTS](https://www.stackage.org/lts-24.31/package/sbv)

Example test failure:

```
Uninterpreted.Axioms
    unint-axioms:                                                                                                                FAIL (0.07s)
      --- SBVTestSuite/GoldFiles/unint-axioms.gold      2001-09-09 01:46:40.000000000 +0000
      +++ SBVTestSuite/GoldFiles/unint-axioms.gold_temp 2023-08-30 06:11:27.754787640 +0000
      @@ -1,4 +1,4 @@
      -** Calling: z3 -nw -in -smt2
      +** Calling: /nix/store/jb2pj6di3fbfdk44dzlc5nfjsx6bj6l5-z3-4.8.17/bin/z3 -nw -in -smt2
       [GOOD] ; Automatically generated by SBV. Do not edit.
       [GOOD] (set-option :print-success true)
       [GOOD] (set-option :global-declarations true)
```