### PR TITLE
Add `sRealToSIntegerRM` and `sRationalToSIntegerRM`

### DIFF
--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -232,7 +232,9 @@ module Data.SBV (
   , SRational, (.%)
   -- ** Algebraic reals
   -- $algReals
-  , SReal, AlgReal(..), sRealToSInteger, algRealToRational, RealPoint(..), realPoint, RationalCV(..)
+  , SReal, AlgReal(..)
+  , sRealToSInteger, sRealToSIntegerRM
+  , algRealToRational, RealPoint(..), realPoint, RationalCV(..)
   -- ** Characters, Strings and Regular Expressions
   -- $strings
   , SChar, SString

--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -229,7 +229,7 @@ module Data.SBV (
   , SFPQuad, FPQuad
   , fpFromInteger
   -- ** Rationals
-  , SRational, (.%)
+  , SRational, (.%), sRationalToSIntegerRM
   -- ** Algebraic reals
   -- $algReals
   , SReal, AlgReal(..)

--- a/Data/SBV.hs
+++ b/Data/SBV.hs
@@ -329,7 +329,7 @@ module Data.SBV (
   -- * IEEE-floating point numbers
   , IEEEFloating(..), RoundingMode(..), SRoundingMode, nan, infinity, sNaN, sInfinity
   -- ** Rounding modes
-  , sRoundNearestTiesToEven, sRoundNearestTiesToAway, sRoundTowardPositive, sRoundTowardNegative, sRoundTowardZero, sRNE, sRNA, sRTP, sRTN, sRTZ
+  , sRoundNearestTiesToEven, sRoundNearestTiesToAway, sRoundTowardPositive, sRoundTowardNegative, sRoundTowardZero, sRNE, sRNA, sRTP, sRTN, sRTZ, sCaseRoundingMode
   -- ** Conversion to/from floats
   -- $conversionNote
   , IEEEFloatConvertible(..)

--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -58,7 +58,8 @@ module Data.SBV.Core.Model (
   , sDivides
   , solve
   , slet
-  , sRealToSInteger, sRealToSIntegerTruncate, label, observe, observeIf, sObserve
+  , sRealToSInteger, sRealToSIntegerTruncate, sRealToSIntegerRM
+  , label, observe, observeIf, sObserve
   , sAssert
   , liftQRem, liftDMod, symbolicMergeWithKind
   , genLiteral, genFromCV, genMkSymVar
@@ -133,7 +134,7 @@ import Data.SBV.Provers.Prover (defaultSMTCfg, SafeResult(..), defs2smt, prove, 
 import Data.SBV.SMT.SMT        (ThmResult(..), showModel)
 import Data.SBV.SMT.Utils      (debug)
 
-import Data.SBV.Utils.Numeric (fpIsEqualObjectH)
+import Data.SBV.Utils.Numeric (fpIsEqualObjectH, roundAway)
 
 import Data.IORef (readIORef, writeIORef, modifyIORef')
 import System.Mem.StableName (makeStableName, hashStableName)
@@ -875,24 +876,125 @@ sSets = symbolics
 solve :: MonadSymbolic m => [SBool] -> m SBool
 solve = pure . sAnd
 
--- | Convert an SReal to an SInteger. That is, it computes the
--- largest integer @n@ that satisfies @sIntegerToSReal n <= r@
--- essentially giving us the @floor@.
+-- | Convert an SReal to an SInteger, @floor@ version. That is, it computes the
+-- largest integer @n@ that satisfies @sIntegerToSReal n <= r@.
 --
 -- For instance, @1.3@ will be @1@, but @-1.3@ will be @-2@.
 sRealToSInteger :: SReal -> SInteger
 sRealToSInteger x
   | Just i <- unliteral x, isExactRational i
-  = literal $ floor (toRational i)
-  | True
+  = literal $ floor $ toRational i
+  | otherwise
   = SBV (SVal KUnbounded (Right (cache y)))
   where y st = do xsv <- sbvToSV st x
                   newExpr st KUnbounded (SBVApp (KindCast KReal KUnbounded) [xsv])
 
+-- | Convert an SReal to an SInteger, @ceiling@ version. That is, it computes
+-- the smallest integer @n@ that satisfies @r <= sIntegerToSReal n@.
+--
+-- For instance, @1.3@ will be @2@, but @-1.3@ will be @-1@.
+sRealToSIntegerCeiling :: SReal -> SInteger
+sRealToSIntegerCeiling x
+  | Just i <- unliteral x, isExactRational i
+  = literal $ ceiling $ toRational i
+  | otherwise
+  = - sRealToSInteger (-x)
+
 -- | Convert an SReal to an SInteger, truncating version. Truncate simply chops of the
 -- fractional part, essentially rounding towards zero.
+--
+-- For instance, @1.3@ will be @1@, and @-1.3@ will be @-1@.
 sRealToSIntegerTruncate :: SReal -> SInteger
-sRealToSIntegerTruncate x = ite (x .>= 0) (sRealToSInteger x) (- sRealToSInteger (-x))
+sRealToSIntegerTruncate x
+  | Just i <- unliteral x, isExactRational i
+  = literal $ truncate $ toRational i
+  | otherwise
+  = ite (x .>= 0) (sRealToSInteger x) (sRealToSIntegerCeiling x)
+
+-- | Convert an SReal to an SInteger by converting to the nearest integer. If
+-- there is a tie (i.e., if the fractional component of the SReal is equal to
+-- 0.5), then round away from zero.
+--
+-- For instance:
+--
+-- * @1.3@ will be @1@
+-- * @1.5@ will be @2@ (because @abs 1 < abs 2@)
+-- * @1.7@ will be @2@
+-- * @2.3@ will be @2@
+-- * @2.5@ will be @3@ (because @abs 2 < abs 3@)
+-- * @2.7@ will be @3@
+-- * @-1.3@ will be @-1@
+-- * @-1.5@ will be @-2@ (because @abs (-1) < abs (-2)@)
+-- * @-1.7@ will be @-2@
+-- * @-2.3@ will be @-2@
+-- * @-2.5@ will be @-3@ (because @abs (-2) < abs (-3)@)
+-- * @-2.7@ will be @-3@
+sRealToSIntegerRoundAway :: SReal -> SInteger
+sRealToSIntegerRoundAway x
+  | Just i <- unliteral x, isExactRational i
+  = literal $ roundAway (toRational i)
+  | otherwise
+  = ite
+      (x .>= 0)
+      (sRealToSInteger        (x + half))
+      (sRealToSIntegerCeiling (x - half))
+  where
+    half :: SReal
+    half = 0.5
+
+-- | Convert an SReal to an SInteger by converting to the nearest integer. If
+-- there is a tie (i.e., if the fractional component of the SReal is equal to
+-- 0.5), then round to the nearest even integer.
+--
+-- For instance:
+--
+-- * @1.3@ will be @1@
+-- * @1.5@ will be @2@ (because @2@ is even)
+-- * @1.7@ will be @2@
+-- * @2.3@ will be @2@
+-- * @2.5@ will be @2@ (because @2@ is even)
+-- * @2.7@ will be @3@
+-- * @-1.3@ will be @-1@
+-- * @-1.5@ will be @-2@ (because @-2@ is even)
+-- * @-1.7@ will be @-2@
+-- * @-2.3@ will be @-2@
+-- * @-2.5@ will be @-2@ (because @-2@) is even)
+-- * @-2.7@ will be @-3@
+sRealToSIntegerRoundToEven :: SReal -> SInteger
+sRealToSIntegerRoundToEven x
+  | Just i <- unliteral x, isExactRational i
+  = literal $ round $ toRational i
+  | otherwise
+  = ite (diff .< half) lo $
+    ite (diff .> half) hi $
+    ite (sDivides 2 lo) lo hi
+  where
+    half :: SReal
+    half = 0.5
+
+    lo, hi :: SInteger
+    lo = sRealToSInteger x
+    hi = lo+1
+
+    diff :: SReal
+    diff = x - sFromIntegral lo
+
+-- | Convert an 'SReal' to an 'SInteger' according to the supplied
+-- 'SRoundingMode'.
+--
+-- Note that we re-use the 'SRoundingMode' type here, even though
+-- 'SRoundingMode' is normally associated with floating-point operations. The
+-- floating-point resemblence is superficial, as this function does not use any
+-- floating-point functionality behind the scenes.
+sRealToSIntegerRM :: SRoundingMode -> SReal -> SInteger
+sRealToSIntegerRM rm x =
+  sCaseRoundingMode
+    (sRealToSIntegerRoundToEven x)
+    (sRealToSIntegerRoundAway x)
+    (sRealToSIntegerCeiling x)
+    (sRealToSInteger x)
+    (sRealToSIntegerTruncate x)
+    rm
 
 -- | label: Label the result of an expression. This is essentially a no-op, but useful as it generates a comment in the generated C/SMT-Lib code.
 -- Note that if the argument is a constant, then the label is dropped completely, per the usual constant folding strategy. Compare this to 'observe'

--- a/Data/SBV/Core/Model.hs
+++ b/Data/SBV/Core/Model.hs
@@ -49,6 +49,7 @@ module Data.SBV.Core.Model (
   , sFloatingPoint, sFloatingPoint_, sFloatingPoints
   , sRoundNearestTiesToEven, sRoundNearestTiesToAway, sRoundTowardPositive, sRoundTowardNegative, sRoundTowardZero
   , sRNE, sRNA, sRTP, sRTN, sRTZ
+  , sCaseRoundingMode
   , sChar, sChar_, sChars, sString, sString_, sStrings, sList, sList_, sLists
   , sRational, sRational_, sRationals
   , SymTuple, sTuple, sTuple_, sTuples
@@ -311,6 +312,28 @@ sRTN = sRoundTowardNegative
 -- | Alias for 'sRoundTowardZero'
 sRTZ :: SRoundingMode
 sRTZ = sRoundTowardZero
+
+-- | Case analyzer for the type 'RoundingMode'.
+sCaseRoundingMode ::
+  Mergeable r =>
+  -- | What to return in the 'sRoundNearestTiesToEven' case.
+  r ->
+  -- | What to return in the 'sRoundNearestTiesToAway' case.
+  r ->
+  -- | What to return in the 'sRoundTowardPositive' case.
+  r ->
+  -- | What to return in the 'sRoundTowardNegative' case.
+  r ->
+  -- | What to return in the 'sRoundTowardPositive' case.
+  r ->
+  SRoundingMode ->
+  r
+sCaseRoundingMode fRNE fRNA fRTP fRTN fRTZ rm =
+  ite (rm .== sRNE) fRNE $
+  ite (rm .== sRNA) fRNA $
+  ite (rm .== sRTP) fRTP $
+  ite (rm .== sRTN) fRTN
+                    fRTZ
 
 
 instance SymVal Char where

--- a/Data/SBV/Rational.hs
+++ b/Data/SBV/Rational.hs
@@ -17,12 +17,15 @@
 module Data.SBV.Rational (
     -- * Constructing rationals
       (.%)
-  ) where
+    -- * Rounding rationals
+    , sRationalToSIntegerRM
+    ) where
 
 import qualified Data.Ratio as R
 
 import Data.SBV.Core.Data
 import Data.SBV.Core.Model
+import Data.SBV.Utils.Numeric (roundAway)
 
 infixl 7 .%
 
@@ -41,6 +44,122 @@ top .% bot
  where res st = do t <- sbvToSV st top
                    b <- sbvToSV st bot
                    newExpr st KRational $ SBVApp RationalConstructor [t, b]
+
+-- | Convert an SRational to an SInteger, @floor@ version. That is, it computes
+-- the largest integer @n@ that satisfies @(n .% 1) <= r@.
+--
+-- For instance, @1.3@ will be @1@, but @-1.3@ will be @-2@.
+sRationalToSIntegerFloor :: SRational -> SInteger
+-- NB: We use @sDiv@ below because it implements division that truncates
+-- towards negative infinity, which is exactly what @floor@ needs.
+sRationalToSIntegerFloor = lift1 floor (uncurry sDiv)
+
+-- | Convert an SRational to an SInteger, @ceiling@ version. That is, it
+-- computes the smallest integer @n@ that satisfies @r <= (n .% 1)@.
+--
+-- For instance, @1.3@ will be @2@, but @-1.3@ will be @-1@.
+sRationalToSIntegerCeiling :: SRational -> SInteger
+sRationalToSIntegerCeiling x
+  | Just i <- unliteral x
+  = literal $ ceiling i
+  | otherwise
+  = - (sRationalToSIntegerFloor (- x))
+
+-- | Convert an SRational to an SInteger, truncating version. Truncate simply
+-- chops of the fractional part, essentially rounding towards zero.
+--
+-- For instance, @1.3@ will be @1@, and @-1.3@ will be @-1@.
+sRationalToSIntegerTruncate :: SRational -> SInteger
+sRationalToSIntegerTruncate x
+  | Just i <- unliteral x
+  = literal $ truncate i
+  | otherwise
+  = ite (x .>= 0) (sRationalToSIntegerFloor x) (sRationalToSIntegerCeiling x)
+
+-- | Convert an SRational to an SInteger by converting to the nearest integer.
+-- If there is a tie (i.e., if the fractional component of the SRational is
+-- equal to 0.5), then round away from zero.
+--
+-- For instance:
+--
+-- * @1.3@ will be @1@
+-- * @1.5@ will be @2@ (because @abs 1 < abs 2@)
+-- * @1.7@ will be @2@
+-- * @2.3@ will be @2@
+-- * @2.5@ will be @3@ (because @abs 2 < abs 3@)
+-- * @2.7@ will be @3@
+-- * @-1.3@ will be @-1@
+-- * @-1.5@ will be @-2@ (because @abs (-1) < abs (-2)@)
+-- * @-1.7@ will be @-2@
+-- * @-2.3@ will be @-2@
+-- * @-2.5@ will be @-3@ (because @abs (-2) < abs (-3)@)
+-- * @-2.7@ will be @-3@
+sRationalToSIntegerRoundAway :: SRational -> SInteger
+sRationalToSIntegerRoundAway x
+  | Just i <- unliteral x
+  = literal $ roundAway i
+  | otherwise
+  = ite
+      (x .>= 0)
+      (sRationalToSIntegerFloor   (x + half))
+      (sRationalToSIntegerCeiling (x - half))
+  where
+    half :: SRational
+    half = 0.5
+
+-- | Convert an SRational to an SInteger by converting to the nearest integer.
+-- If there is a tie (i.e., if the fractional component of the SRational is
+-- equal to 0.5), then round to the nearest even integer.
+--
+-- For instance:
+--
+-- * @1.3@ will be @1@
+-- * @1.5@ will be @2@ (because @2@ is even)
+-- * @1.7@ will be @2@
+-- * @2.3@ will be @2@
+-- * @2.5@ will be @2@ (because @2@ is even)
+-- * @2.7@ will be @3@
+-- * @-1.3@ will be @-1@
+-- * @-1.5@ will be @-2@ (because @-2@ is even)
+-- * @-1.7@ will be @-2@
+-- * @-2.3@ will be @-2@
+-- * @-2.5@ will be @-2@ (because @-2@) is even)
+-- * @-2.7@ will be @-3@
+sRationalToSIntegerRoundToEven :: SRational -> SInteger
+sRationalToSIntegerRoundToEven x
+  | Just i <- unliteral x
+  = literal $ round i
+  | otherwise
+  = ite (diff .< half) lo $
+    ite (diff .> half) hi $
+    ite (sDivides 2 lo) lo hi
+  where
+    half :: SRational
+    half = 0.5
+
+    lo, hi :: SInteger
+    lo = sRationalToSIntegerFloor x
+    hi = lo+1
+
+    diff :: SRational
+    diff = x - (lo .% 1)
+
+-- | Convert an 'SRational' to an 'SInteger' according to the supplied
+-- 'SRoundingMode'.
+--
+-- Note that we re-use the 'SRoundingMode' type here, even though
+-- 'SRoundingMode' is normally associated with floating-point operations. The
+-- floating-point resemblence is superficial, as this function does not use any
+-- floating-point functionality behind the scenes.
+sRationalToSIntegerRM :: SRoundingMode -> SRational -> SInteger
+sRationalToSIntegerRM rm x =
+  sCaseRoundingMode
+    (sRationalToSIntegerRoundToEven x)
+    (sRationalToSIntegerRoundAway x)
+    (sRationalToSIntegerCeiling x)
+    (sRationalToSIntegerFloor x)
+    (sRationalToSIntegerTruncate x)
+    rm
 
 -- | Get the numerator. Note that this is always symbolic since we don't have a concrete representation.
 -- Furthermore this is only used internally and is not exported to the user, since it is not canonical.

--- a/Data/SBV/Utils/Numeric.hs
+++ b/Data/SBV/Utils/Numeric.hs
@@ -16,6 +16,7 @@
 
 module Data.SBV.Utils.Numeric (
            fpMaxH, fpMinH, fp2fp, fpRemH, fpRoundToIntegralH, fpIsEqualObjectH, fpCompareObjectH, fpIsNormalizedH
+         , roundAway
          , floatToWord, wordToFloat, doubleToWord, wordToDouble
          , RoundingMode(..), smtRoundingMode
          ) where
@@ -124,6 +125,22 @@ fpCompareObjectH a b
 -- and also this is not simply the negation of isDenormalized!
 fpIsNormalizedH :: RealFloat a => a -> Bool
 fpIsNormalizedH x = not (isDenormalized x || isInfinite x || isNaN x || x == 0)
+
+-- | @'roundAway' x@ returns the nearest integer to @x@; the integer furthest
+-- away from @0@ if @x@ is equidistant between two integers.
+
+-- This implementation is taken directly from the @fp-ieee@ library. Somewhat
+-- surprisingly, 'roundAway' is not a method of the 'RealFrac' class!
+roundAway :: (RealFrac a, Integral b) => a -> b
+roundAway x = case properFraction x of
+                -- x == n + f, signum x == signum f, 0 <= abs f < 1
+                (n,r) -> if abs r < 0.5 then
+                           n
+                         else
+                           if r < 0 then
+                             n - 1
+                           else
+                             n + 1
 
 -------------------------------------------------------------------------
 -- Reinterpreting float/double as word32/64 and back. Here, we use the


### PR DESCRIPTION
In order to support symbolic rounding modes, I found it convenient to define an auxiliary `sCaseRoundingMode` function. Since `sbv` already exposes similar `sCaseMaybe` and `sCaseEither` functions, I decided to go ahead and export `sCaseRoundingMode` as part of the public API. If you'd prefer, I could keep `sCaseRoundingMode` internal to `sbv`.

Fixes #797.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LeventErkok/sbv/801)
<!-- Reviewable:end -->
