### PR TITLE
Parse one more representation of sets

### DIFF
--- a/Data/SBV/Utils/SExpr.hs
+++ b/Data/SBV/Utils/SExpr.hs
@@ -506,6 +506,7 @@ parseStoreAssociations e                                           = Right <$> (
     where vals :: SExpr -> Maybe [Either ([SExpr], SExpr) SExpr]
           vals (EApp [EApp [ECon "as", ECon "const", ECon "Array"],            defVal]) = pure [Right defVal]
           vals (EApp [EApp [ECon "as", ECon "const", EApp (ECon "Array" : _)], defVal]) = pure [Right defVal]
+          vals (EApp [ECon "const", defVal])                                            = pure [Right defVal]
           vals (EApp (ECon "store" : prev : argsVal)) | length argsVal >= 2             = do rest <- vals prev
                                                                                              pure $ Left (init argsVal, last argsVal) : rest
           vals _                                                                        = Nothing


### PR DESCRIPTION
```
*** Data.SBV.interpretSet: Unable to process solver output.
***
*** Kind    : {SInteger}
*** Received: EApp [ECon "store",EApp [ECon "const",ENum (0,Nothing,True)],ENum (2,Nothing,False),ENum (1,Nothing,True)]
*** Reason  : Expected a set value, but couldn't decipher the solver output.
***
*** This is either a bug or something SBV currently does not support.
*** Please report this as a feature request!
```

This PR adds a case for specifically `EApp [ECon "const", defVal]`, which resolves the issue on the specific program that triggered the above error. I've not tested this otherwise, nor consulted any documentation, but it seems reasonable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LeventErkok/sbv/812)
<!-- Reviewable:end -->
